### PR TITLE
Trusted time issue

### DIFF
--- a/src/slmgr-ps.psd1
+++ b/src/slmgr-ps.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'slmgr-ps.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.2.1'
+    ModuleVersion     = '0.2.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/slmgr-ps.psm1
+++ b/src/slmgr-ps.psm1
@@ -654,7 +654,11 @@ WHERE LicenseStatus <> 0 AND Name LIKE "Windows%"'
     $status = [LicenseStatusCode]( $product.LicenseStatus)
     $remainingAppRearm = $product.RemainingAppReArmCount
     $remainingSkuRearm = $product.RemainingSkuReArmCount
-    $trustedTime = [datetime]::Parse($product.Trustedtime)
+    $trustedTime = ''
+    if ($null -ne $product.Trustedtime)
+    {
+        $trustedTime = [datetime]::Parse($product.Trustedtime)
+    }
 
     $result = [PSCustomObject]@{
         Name                       = $name

--- a/src/slmgr-ps.psm1
+++ b/src/slmgr-ps.psm1
@@ -655,7 +655,7 @@ WHERE LicenseStatus <> 0 AND Name LIKE "Windows%"'
     $remainingAppRearm = $product.RemainingAppReArmCount
     $remainingSkuRearm = $product.RemainingSkuReArmCount
     $trustedTime = ''
-    if ($null -ne $product.Trustedtime)
+    if ([string]::IsNullOrEmpty($product.Trustedtime) -eq $false)
     {
         $trustedTime = [datetime]::Parse($product.Trustedtime)
     }


### PR DESCRIPTION
The "Trusted Time" property can be empty when `Start-WindowsActivation` command is run and waiting for a reboot. In order to prevent noisy parsing error, a null check is added