### PR TITLE
Fix 35+ bugs identified across three code reviews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,116 @@
+name: CI
+
+on:
+  push:
+    branches: [main, 'claude/**']
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: PSScriptAnalyzer
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name PSScriptAnalyzer -Force -SkipPublisherCheck
+
+      - name: Run PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          $results = Invoke-ScriptAnalyzer -Path ./src -Recurse -Severity Error, Warning
+          if ($results) { $results | Format-Table -AutoSize }
+          $errors = @($results | Where-Object { $_.Severity -eq 'Error' })
+          if ($errors.Count -gt 0)
+          {
+              Write-Error "PSScriptAnalyzer found $($errors.Count) error(s)"
+              exit 1
+          }
+
+  manifest:
+    name: Module manifest
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate manifest
+        shell: pwsh
+        run: Test-ModuleManifest -Path ./src/slmgr-ps.psd1 | Out-Null
+
+      - name: Import module
+        shell: pwsh
+        run: Import-Module ./src/slmgr-ps.psd1 -Force
+
+      - name: Verify only public functions are exported
+        shell: pwsh
+        run: |
+          $module = Get-Module slmgr-ps
+          $exported = $module.ExportedFunctions.Keys | Sort-Object
+          $expected = @('Get-WindowsActivation', 'Start-WindowsActivation') | Sort-Object
+          if (Compare-Object $exported $expected)
+          {
+              Write-Error "Exported functions do not match expected: got [$($exported -join ', ')], expected [$($expected -join ', ')]"
+              exit 1
+          }
+
+  test-ps51:
+    name: Pester (PowerShell 5.1)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Pester
+        shell: powershell
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name Pester -MinimumVersion 5.0 -Force -SkipPublisherCheck
+
+      - name: Run Pester tests
+        shell: powershell
+        run: |
+          $config = New-PesterConfiguration
+          $config.Run.Path = './tests'
+          $config.Output.Verbosity = 'Detailed'
+          $config.TestResult.Enabled = $true
+          $config.TestResult.OutputPath = './test-results-ps51.xml'
+          $results = Invoke-Pester -Configuration $config
+          if ($results.FailedCount -gt 0) { exit 1 }
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-ps51
+          path: ./test-results-ps51.xml
+
+  test-ps7:
+    name: Pester (PowerShell 7)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Pester
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name Pester -MinimumVersion 5.0 -Force -SkipPublisherCheck
+
+      - name: Run Pester tests
+        shell: pwsh
+        run: |
+          $config = New-PesterConfiguration
+          $config.Run.Path = './tests'
+          $config.Output.Verbosity = 'Detailed'
+          $config.TestResult.Enabled = $true
+          $config.TestResult.OutputPath = './test-results-ps7.xml'
+          $results = Invoke-Pester -Configuration $config
+          if ($results.FailedCount -gt 0) { exit 1 }
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-ps7
+          path: ./test-results-ps7.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,10 @@ jobs:
         shell: pwsh
         run: Test-ModuleManifest -Path ./src/slmgr-ps.psd1 | Out-Null
 
-      - name: Import module
-        shell: pwsh
-        run: Import-Module ./src/slmgr-ps.psd1 -Force
-
-      - name: Verify only public functions are exported
+      - name: Import module and verify exports
         shell: pwsh
         run: |
+          Import-Module ./src/slmgr-ps.psd1 -Force
           $module = Get-Module slmgr-ps
           $exported = $module.ExportedFunctions.Keys | Sort-Object
           $expected = @('Get-WindowsActivation', 'Start-WindowsActivation') | Sort-Object

--- a/src/Private/Get-BasicLicenseInformation.ps1
+++ b/src/Private/Get-BasicLicenseInformation.ps1
@@ -6,22 +6,13 @@ function Get-BasicLicenseInformation
         [Microsoft.Management.Infrastructure.CimSession]$CimSession
     )
 
-    $query = 'SELECT ID,Name,Description,PartialProductKey,LicenseStatus
-    FROM SoftwareLicensingProduct
-    WHERE LicenseStatus <> 0 AND Name LIKE "Windows%"'
-
-    $product = Get-CimInstance -CimSession $CimSession -Query $query | Select-Object -First 1
-
-    $name = $product.Name
-    $desc = $product.Description
-    $partial = $product.PartialProductKey
-    $status = [LicenseStatusCode]($product.LicenseStatus)
+    $product = Get-WindowsLicensingProduct -CimSession $CimSession
 
     $result = [PSCustomObject]@{
-        Name                  = $name
-        Description           = $desc
-        'Partial Product Key' = $partial
-        'License Status'      = $status
+        Name              = $product.Name
+        Description       = $product.Description
+        PartialProductKey = $product.PartialProductKey
+        LicenseStatus     = [LicenseStatusCode]($product.LicenseStatus)
     }
     return $result
 }

--- a/src/Private/Get-BasicLicenseInformation.ps1
+++ b/src/Private/Get-BasicLicenseInformation.ps1
@@ -10,7 +10,7 @@ function Get-BasicLicenseInformation
     FROM SoftwareLicensingProduct
     WHERE LicenseStatus <> 0 AND Name LIKE "Windows%"'
 
-    $product = Get-CimInstance -CimSession $CimSession -Query $query
+    $product = Get-CimInstance -CimSession $CimSession -Query $query | Select-Object -First 1
 
     $name = $product.Name
     $desc = $product.Description

--- a/src/Private/Get-ExpiryInformation.ps1
+++ b/src/Private/Get-ExpiryInformation.ps1
@@ -10,41 +10,42 @@ function Get-ExpiryInformation
     FROM SoftwareLicensingProduct
     WHERE LicenseStatus <> 0 AND Name LIKE "Windows%"'
 
-    $product = Get-CimInstance -CimSession $CimSession -Query $query
+    $product = Get-CimInstance -CimSession $CimSession -Query $query | Select-Object -First 1
 
     $name = $product.Name
     $status = [LicenseStatusCode]($product.LicenseStatus)
     $graceRemaining = $product.GracePeriodRemaining
-    $endDate = (Get-Date).AddMinutes($graceRemaining)
 
     $expirationInfo = switch ($product.LicenseStatus)
     {
-        0 { [LicenseStatusCode]::Unlicensed.ToString() }
         1
         {
-            if ($graceRemaining -eq 0)
+            if ($null -eq $graceRemaining -or $graceRemaining -eq 0)
             {
                 'The machine is permanently activated.'
             }
             else
             {
-                if ($product.Description -icontains 'TIMEBASED_')
+                $endDate = (Get-Date).AddMinutes($graceRemaining)
+                if ($product.Description -imatch 'TIMEBASED_')
                 {
                     "Timebased activation will expire $endDate"
                 }
-                elif($product.Description -icontains 'VIRTUAL_MACHINE_ACTIVATION') {
+                elseif ($product.Description -imatch 'VIRTUAL_MACHINE_ACTIVATION')
+                {
                     "Automatic VM activation will expire $endDate"
                 }
-                else {
+                else
+                {
                     "Volume activation will expire $endDate"
                 }
             }
         }
-        2 { "Initial grace period ends $endDate" }
-        3 { "Additional grace period ends $endDate" }
-        4 { "Non-genuine grace period ends $endDate" }
+        2 { $endDate = (Get-Date).AddMinutes($graceRemaining); "Initial grace period ends $endDate" }
+        3 { $endDate = (Get-Date).AddMinutes($graceRemaining); "Additional grace period ends $endDate" }
+        4 { $endDate = (Get-Date).AddMinutes($graceRemaining); "Non-genuine grace period ends $endDate" }
         5 { 'Windows is in Notification mode' }
-        6 { "Extended grace period ends $endDate" }
+        6 { $endDate = (Get-Date).AddMinutes($graceRemaining); "Extended grace period ends $endDate" }
         Default
         {
             throw 'Unexpected license status'

--- a/src/Private/Get-ExpiryInformation.ps1
+++ b/src/Private/Get-ExpiryInformation.ps1
@@ -6,18 +6,13 @@ function Get-ExpiryInformation
         [Microsoft.Management.Infrastructure.CimSession]$CimSession
     )
 
-    $query = 'SELECT ID, Description, Name, LicenseStatus, GracePeriodRemaining
-    FROM SoftwareLicensingProduct
-    WHERE LicenseStatus <> 0 AND Name LIKE "Windows%"'
-
-    $product = Get-CimInstance -CimSession $CimSession -Query $query | Select-Object -First 1
-
-    $name = $product.Name
+    $product = Get-WindowsLicensingProduct -CimSession $CimSession
     $status = [LicenseStatusCode]($product.LicenseStatus)
     $graceRemaining = $product.GracePeriodRemaining
 
     $expirationInfo = switch ($product.LicenseStatus)
     {
+        0 { [LicenseStatusCode]::Unlicensed.ToString() }
         1
         {
             if ($null -eq $graceRemaining -or $graceRemaining -eq 0)
@@ -41,21 +36,18 @@ function Get-ExpiryInformation
                 }
             }
         }
-        2 { $endDate = (Get-Date).AddMinutes($graceRemaining); "Initial grace period ends $endDate" }
-        3 { $endDate = (Get-Date).AddMinutes($graceRemaining); "Additional grace period ends $endDate" }
-        4 { $endDate = (Get-Date).AddMinutes($graceRemaining); "Non-genuine grace period ends $endDate" }
+        2 { "Initial grace period ends $((Get-Date).AddMinutes($graceRemaining))" }
+        3 { "Additional grace period ends $((Get-Date).AddMinutes($graceRemaining))" }
+        4 { "Non-genuine grace period ends $((Get-Date).AddMinutes($graceRemaining))" }
         5 { 'Windows is in Notification mode' }
-        6 { $endDate = (Get-Date).AddMinutes($graceRemaining); "Extended grace period ends $endDate" }
-        Default
-        {
-            throw 'Unexpected license status'
-        }
+        6 { "Extended grace period ends $((Get-Date).AddMinutes($graceRemaining))" }
+        Default { throw 'Unexpected license status' }
     }
 
     $result = [PSCustomObject]@{
-        Name                     = $name
-        'License Status'         = $status
-        'Expiration Information' = $expirationInfo
+        Name           = $product.Name
+        LicenseStatus  = $status
+        ExpirationInfo = $expirationInfo
     }
     return $result
 }

--- a/src/Private/Get-ExtendedLicenseInformation.ps1
+++ b/src/Private/Get-ExtendedLicenseInformation.ps1
@@ -6,25 +6,8 @@ function Get-ExtendedLicenseInformation
         [Microsoft.Management.Infrastructure.CimSession]$CimSession
     )
 
-    $query = 'SELECT Name,Description,ID,ApplicationID,ProductKeyID,ProductKeyChannel,OfflineInstallationId,UseLicenseURL,ValidationURL,PartialProductKey,LicenseStatus,RemainingAppReArmCount,RemainingSkuReArmCount,TrustedTime
-    FROM SoftwareLicensingProduct
-    WHERE LicenseStatus <> 0 AND Name LIKE "Windows%"'
+    $product = Get-WindowsLicensingProduct -CimSession $CimSession
 
-    $product = Get-CimInstance -CimSession $CimSession -Query $query | Select-Object -First 1
-
-    $name = $product.Name
-    $desc = $product.Description
-    $activationID = $product.ID
-    $applicationID = $product.ApplicationID
-    $pkID = $product.ProductKeyID
-    $pkChannel = $product.ProductKeyChannel
-    $installationID = $product.OfflineInstallationId
-    $licenseUrl = $product.UseLicenseURL
-    $validationUrl = $product.ValidationURL
-    $partial = $product.PartialProductKey
-    $status = [LicenseStatusCode]($product.LicenseStatus)
-    $remainingAppRearm = $product.RemainingAppReArmCount
-    $remainingSkuRearm = $product.RemainingSkuReArmCount
     $trustedTime = [datetime]::MinValue
     if ($null -ne $product.TrustedTime)
     {
@@ -32,20 +15,20 @@ function Get-ExtendedLicenseInformation
     }
 
     $result = [PSCustomObject]@{
-        Name                            = $name
-        Description                     = $desc
-        'Activation ID'                 = $activationID
-        'Application ID'                = $applicationID
-        'Extended PID'                  = $pkID
-        'Product Key Channel'           = $pkChannel
-        'Installation ID'               = $installationID
-        'Use License URL'               = $licenseUrl
-        'Validation URL'                = $validationUrl
-        'Partial Product Key'           = $partial
-        'License Status'                = $status
-        'Remaining Windows Rearm Count' = $remainingAppRearm
-        'Remaining SKU Rearm Count'     = $remainingSkuRearm
-        'Trusted Time'                  = $trustedTime
+        Name                       = $product.Name
+        Description                = $product.Description
+        ActivationId               = $product.ID
+        ApplicationId              = $product.ApplicationID
+        ExtendedPid                = $product.ProductKeyID
+        ProductKeyChannel          = $product.ProductKeyChannel
+        InstallationId             = $product.OfflineInstallationId
+        UseLicenseUrl              = $product.UseLicenseURL
+        ValidationUrl              = $product.ValidationURL
+        PartialProductKey          = $product.PartialProductKey
+        LicenseStatus              = [LicenseStatusCode]($product.LicenseStatus)
+        RemainingWindowsRearmCount = $product.RemainingAppReArmCount
+        RemainingSkuRearmCount     = $product.RemainingSkuReArmCount
+        TrustedTime                = $trustedTime
     }
     return $result
 }

--- a/src/Private/Get-ExtendedLicenseInformation.ps1
+++ b/src/Private/Get-ExtendedLicenseInformation.ps1
@@ -10,7 +10,7 @@ function Get-ExtendedLicenseInformation
     FROM SoftwareLicensingProduct
     WHERE LicenseStatus <> 0 AND Name LIKE "Windows%"'
 
-    $product = Get-CimInstance -CimSession $CimSession -Query $query
+    $product = Get-CimInstance -CimSession $CimSession -Query $query | Select-Object -First 1
 
     $name = $product.Name
     $desc = $product.Description
@@ -22,7 +22,7 @@ function Get-ExtendedLicenseInformation
     $licenseUrl = $product.UseLicenseURL
     $validationUrl = $product.ValidationURL
     $partial = $product.PartialProductKey
-    $status = [LicenseStatusCode]( $product.LicenseStatus)
+    $status = [LicenseStatusCode]($product.LicenseStatus)
     $remainingAppRearm = $product.RemainingAppReArmCount
     $remainingSkuRearm = $product.RemainingSkuReArmCount
     $trustedTime = [datetime]::MinValue

--- a/src/Private/Get-KMSKey.ps1
+++ b/src/Private/Get-KMSKey.ps1
@@ -2,7 +2,7 @@
 # Update as needed
 function Get-KMSKey
 {
-    [OutputType([PSCustomObject])]
+    [OutputType([string])]
     [CmdletBinding()]
     param(
         [Microsoft.Management.Infrastructure.CimSession]$CimSession
@@ -13,33 +13,53 @@ function Get-KMSKey
     $productKey = switch -Wildcard ($OsVersion)
     {
         # End of support: Oct 09, 2029
-        'Microsoft Windows Server 2025 Standard*' { 'TVRH6-WHNXV-R9WG3-9XRFY-MY832' }
-        'Microsoft Windows Server 2025 Datacenter*' { 'D764K-2NDRG-47T6Q-P8T8W-YP6DF' }
-        
+        'Microsoft Windows Server 2025 Standard*'                  { 'TVRH6-WHNXV-R9WG3-9XRFY-MY832'; break }
+        'Microsoft Windows Server 2025 Datacenter: Azure Edition*' { 'XGN3F-F394H-FD2MY-PP6FD-8MCRC'; break }
+        'Microsoft Windows Server 2025 Datacenter*'                { 'D764K-2NDRG-47T6Q-P8T8W-YP6DF'; break }
+
         # End of support: Oct 13, 2026
-        'Microsoft Windows Server 2022 Standard*' { 'VDYBN-27WPP-V4HQT-9VMD4-VMK7H' }
-        'Microsoft Windows Server 2022 Datacenter*' { 'WX4NM-KYWYW-QJJR4-XV3QB-6VM33' }
+        'Microsoft Windows Server 2022 Standard*'                  { 'VDYBN-27WPP-V4HQT-9VMD4-VMK7H'; break }
+        'Microsoft Windows Server 2022 Datacenter: Azure Edition*' { 'NTBV8-9K7Q8-V27C6-M2BTV-KHMXV'; break }
+        'Microsoft Windows Server 2022 Datacenter*'                { 'WX4NM-KYWYW-QJJR4-XV3QB-6VM33'; break }
 
-        # End of support: Jan 9, 2024
-        'Microsoft Windows Server 2019 Standard*' { 'N69G4-B89J2-4G8F4-WWYCC-J464C' }
-        'Microsoft Windows Server 2019 Datacenter*' { 'WMDGN-G9PQG-XVVXX-R3X43-63DFG' }
-        'Microsoft Windows Server 2019 Essentials*' { 'WVDHN-86M7X-466P6-VHXV7-YY726' }
+        # End of support: Jan 9, 2029
+        'Microsoft Windows Server 2019 Standard*'                  { 'N69G4-B89J2-4G8F4-WWYCC-J464C'; break }
+        'Microsoft Windows Server 2019 Datacenter*'                { 'WMDGN-G9PQG-XVVXX-R3X43-63DFG'; break }
+        'Microsoft Windows Server 2019 Essentials*'                { 'WVDHN-86M7X-466P6-VHXV7-YY726'; break }
 
-        # End of support: Oct 8, 2024 for 22H2
-        'Microsoft Windows 11 Enterprise N' { 'DPH2V-TTNVB-4X9Q3-TJR4H-KHJW4' }
-        'Microsoft Windows 11 Enterprise' { 'NPPR9-FWDCX-D2C8J-H872K-2YT43' }
-        'Microsoft Windows 11 Pro for Workstations' { 'NRG8B-VKK3Q-CXVCJ-9G2XF-6Q84J' }
-        'Microsoft Windows 11 Pro for Workstations N' { '9FNHH-K3HBT-3W4TD-6383H-6XYWF' }
-        'Microsoft Windows 11 Pro N' { 'MH37W-N47XK-V7XM9-C7227-GCQG9' }
-        'Microsoft Windows 11 Pro' { 'W269N-WFGWX-YVC9B-4J6C9-T83GX' }
+        # End of support: Jan 12, 2027
+        'Microsoft Windows Server 2016 Standard*'                  { 'WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY'; break }
+        'Microsoft Windows Server 2016 Datacenter*'                { 'CB7KF-BWN84-R7R2Y-793K2-8XDDG'; break }
+        'Microsoft Windows Server 2016 Essentials*'                { 'JCKRF-N37P4-C2D82-9YXRT-4M63B'; break }
 
-        # End of support: Oct 14, 2025
-        'Microsoft Windows 10 Enterprise N' { 'DPH2V-TTNVB-4X9Q3-TJR4H-KHJW4' }
-        'Microsoft Windows 10 Enterprise' { 'NPPR9-FWDCX-D2C8J-H872K-2YT43' }
-        'Microsoft Windows 10 Pro for Workstations' { 'NRG8B-VKK3Q-CXVCJ-9G2XF-6Q84J' }
-        'Microsoft Windows 10 Pro for Workstations N' { '9FNHH-K3HBT-3W4TD-6383H-6XYWF' }
-        'Microsoft Windows 10 Pro N' { 'MH37W-N47XK-V7XM9-C7227-GCQG9' }
-        'Microsoft Windows 10 Pro' { 'W269N-WFGWX-YVC9B-4J6C9-T83GX' }
+        # More specific patterns must appear before general ones so the first match with break wins.
+        # Windows 11 - End of support: Oct 2024 for 22H2; LTSC 2024 supported until Oct 2034
+        'Microsoft Windows 11 Enterprise LTSC*'                    { 'M7XTQ-FN8P6-TTKYV-9D4CC-J462D'; break }
+        'Microsoft Windows 11 Enterprise N LTSC*'                  { '92NFX-8DJQP-P6BBQ-THF9C-7CG2H'; break }
+        'Microsoft Windows 11 Enterprise N*'                       { 'DPH2V-TTNVB-4X9Q3-TJR4H-KHJW4'; break }
+        'Microsoft Windows 11 Enterprise*'                         { 'NPPR9-FWDCX-D2C8J-H872K-2YT43'; break }
+        'Microsoft Windows 11 Education N*'                        { '2WH4N-8QGBV-H22JP-CT43Q-MDWWJ'; break }
+        'Microsoft Windows 11 Education*'                          { 'NW6C2-QMPVW-D7KKK-3GKT6-VCFB2'; break }
+        'Microsoft Windows 11 Pro for Workstations N*'             { '9FNHH-K3HBT-3W4TD-6383H-6XYWF'; break }
+        'Microsoft Windows 11 Pro for Workstations*'               { 'NRG8B-VKK3Q-CXVCJ-9G2XF-6Q84J'; break }
+        'Microsoft Windows 11 Pro Education N*'                    { 'YVWGF-BXNMC-HTQYQ-CPQ99-66QFC'; break }
+        'Microsoft Windows 11 Pro Education*'                      { '6TP4R-GNPTD-KYYHQ-7B7DP-J447Y'; break }
+        'Microsoft Windows 11 Pro N*'                              { 'MH37W-N47XK-V7XM9-C7227-GCQG9'; break }
+        'Microsoft Windows 11 Pro*'                                { 'W269N-WFGWX-YVC9B-4J6C9-T83GX'; break }
+
+        # Windows 10 - End of support: Oct 2025 for 22H2; LTSC 2021 supported until Jan 2027
+        'Microsoft Windows 10 Enterprise LTSC*'                    { 'M7XTQ-FN8P6-TTKYV-9D4CC-J462D'; break }
+        'Microsoft Windows 10 Enterprise N LTSC*'                  { '92NFX-8DJQP-P6BBQ-THF9C-7CG2H'; break }
+        'Microsoft Windows 10 Enterprise N*'                       { 'DPH2V-TTNVB-4X9Q3-TJR4H-KHJW4'; break }
+        'Microsoft Windows 10 Enterprise*'                         { 'NPPR9-FWDCX-D2C8J-H872K-2YT43'; break }
+        'Microsoft Windows 10 Education N*'                        { '2WH4N-8QGBV-H22JP-CT43Q-MDWWJ'; break }
+        'Microsoft Windows 10 Education*'                          { 'NW6C2-QMPVW-D7KKK-3GKT6-VCFB2'; break }
+        'Microsoft Windows 10 Pro for Workstations N*'             { '9FNHH-K3HBT-3W4TD-6383H-6XYWF'; break }
+        'Microsoft Windows 10 Pro for Workstations*'               { 'NRG8B-VKK3Q-CXVCJ-9G2XF-6Q84J'; break }
+        'Microsoft Windows 10 Pro Education N*'                    { 'YVWGF-BXNMC-HTQYQ-CPQ99-66QFC'; break }
+        'Microsoft Windows 10 Pro Education*'                      { '6TP4R-GNPTD-KYYHQ-7B7DP-J447Y'; break }
+        'Microsoft Windows 10 Pro N*'                              { 'MH37W-N47XK-V7XM9-C7227-GCQG9'; break }
+        'Microsoft Windows 10 Pro*'                                { 'W269N-WFGWX-YVC9B-4J6C9-T83GX'; break }
 
         default { 'Unknown' }
     }

--- a/src/Private/Get-LicenseStatus.ps1
+++ b/src/Private/Get-LicenseStatus.ps1
@@ -10,9 +10,9 @@ function Get-LicenseStatus
     FROM SoftwareLicensingProduct
     WHERE LicenseStatus <> 0 AND Name LIKE "Windows%"'
 
-    $product = Get-CimInstance -CimSession $CimSession -Query $query
+    $product = Get-CimInstance -CimSession $CimSession -Query $query | Select-Object -First 1
 
-    $status = [LicenseStatusCode]($product.LicenseStatus).LicenseStatus
+    $status = [LicenseStatusCode]($product.LicenseStatus)
     $activated = $status -eq [LicenseStatusCode]::Licensed
     $result = [PSCustomObject]@{
         'License Status' = $status

--- a/src/Private/Get-LicenseStatus.ps1
+++ b/src/Private/Get-LicenseStatus.ps1
@@ -6,17 +6,12 @@ function Get-LicenseStatus
         [Microsoft.Management.Infrastructure.CimSession]$CimSession
     )
 
-    $query = 'SELECT ID, LicenseStatus, Name
-    FROM SoftwareLicensingProduct
-    WHERE LicenseStatus <> 0 AND Name LIKE "Windows%"'
-
-    $product = Get-CimInstance -CimSession $CimSession -Query $query | Select-Object -First 1
-
+    $product = Get-WindowsLicensingProduct -CimSession $CimSession
     $status = [LicenseStatusCode]($product.LicenseStatus)
     $activated = $status -eq [LicenseStatusCode]::Licensed
     $result = [PSCustomObject]@{
-        'License Status' = $status
-        Activated        = $activated
+        LicenseStatus = $status
+        Activated     = $activated
     }
     return $result
 }

--- a/src/Private/Get-OfflineInstallationId.ps1
+++ b/src/Private/Get-OfflineInstallationId.ps1
@@ -6,14 +6,10 @@ function Get-OfflineInstallationId
         [Microsoft.Management.Infrastructure.CimSession]$CimSession
     )
 
-    $query = 'SELECT ID, Name, OfflineInstallationId, PartialProductKey
-    FROM SoftwareLicensingProduct
-    WHERE (PartialProductKey IS NOT NULL AND Name LIKE "Windows%")'
-
-    $product = Get-CimInstance -CimSession $CimSession -Query $query | Select-Object -First 1
+    $product = Get-WindowsLicensingProduct -CimSession $CimSession
 
     $result = [PSCustomObject]@{
-        'Offline Installation Id' = $product.OfflineInstallationId
+        OfflineInstallationId = $product.OfflineInstallationId
     }
     return $result
 }

--- a/src/Private/Get-OfflineInstallationId.ps1
+++ b/src/Private/Get-OfflineInstallationId.ps1
@@ -8,9 +8,9 @@ function Get-OfflineInstallationId
 
     $query = 'SELECT ID, Name, OfflineInstallationId, PartialProductKey
     FROM SoftwareLicensingProduct
-    WHERE (PartialProductKey <> null AND Name LIKE "Windows%")'
+    WHERE (PartialProductKey IS NOT NULL AND Name LIKE "Windows%")'
 
-    $product = Get-CimInstance -CimSession $CimSession -Query $query
+    $product = Get-CimInstance -CimSession $CimSession -Query $query | Select-Object -First 1
 
     $result = [PSCustomObject]@{
         'Offline Installation Id' = $product.OfflineInstallationId

--- a/src/Private/Get-Session.ps1
+++ b/src/Private/Get-Session.ps1
@@ -12,22 +12,25 @@ function Get-Session
 
     Write-Verbose "Creating sessions for $($Computer.Count) hosts"
 
-    if ($Computer.Count -eq 1 -and $Computer[0] -eq 'localhost' -or $Computer[0] -eq '.' -or $Computer[0] -eq '127.0.0.1' -or $null -eq $Computer[0])
+    if ($Computer.Count -eq 1 -and ($Computer[0] -eq 'localhost' -or $Computer[0] -eq '.' -or $Computer[0] -eq '127.0.0.1' -or $null -eq $Computer[0]))
     {
         Write-Verbose 'Using DCOM protocol for CIM session'
+        $dcomOption = New-CimSessionOption -Protocol Dcom
         if ($null -eq $Credentials)
         {
-            $session = New-CimSession -Name 'SlmgrLocalSession'
+            $session = New-CimSession -SessionOption $dcomOption -Name 'SlmgrLocalSession'
         }
         else
         {
-            $session = New-CimSession -Name 'SlmgrLocalSession' -Credential $Credentials
+            $session = New-CimSession -SessionOption $dcomOption -Name 'SlmgrLocalSession' -Credential $Credentials
         }
     }
     else # if multiple hosts are given including localhost, then it will try to use WinRM, instead of DCOM.
     {
         Write-Verbose 'Using WinRM protocol for CIM session'
-        $session = New-CimSession $PSBoundParameters -Name 'SlmgrRemoteSession'
+        $sessionParams = @{ ComputerName = $Computer; Name = 'SlmgrRemoteSession' }
+        if ($null -ne $Credentials) { $sessionParams['Credential'] = $Credentials }
+        $session = New-CimSession @sessionParams
     }
     return $session
 }

--- a/src/Private/Get-WindowsLicensingProduct.ps1
+++ b/src/Private/Get-WindowsLicensingProduct.ps1
@@ -35,5 +35,5 @@ function Get-WindowsLicensingProduct
     if ($active.Count -eq 1) { return $active[0] }
 
     $summary = ($candidates | ForEach-Object { "'$($_.Name)' (status $($_.LicenseStatus))" }) -join ', '
-    throw "Multiple Windows licensing products found and none can be selected unambiguously: $summary. Use -ActivationId to target a specific product."
+    throw "Multiple Windows licensing products found and none can be selected unambiguously: $summary. Remove duplicate product registrations or contact your administrator."
 }

--- a/src/Private/Get-WindowsLicensingProduct.ps1
+++ b/src/Private/Get-WindowsLicensingProduct.ps1
@@ -1,0 +1,39 @@
+function Get-WindowsLicensingProduct
+{
+    [OutputType([CimInstance])]
+    [CmdletBinding()]
+    param(
+        [Microsoft.Management.Infrastructure.CimSession]$CimSession
+    )
+
+    # ApplicationID '55c92734-d682-4d71-983e-d6ec3f16059f' is the Windows OS licensing application.
+    # PartialProductKey IS NOT NULL ensures a product key is actually installed (excludes evaluation stubs).
+    $query = "SELECT Name, Description, ID, ApplicationID, ProductKeyID, ProductKeyChannel,
+    OfflineInstallationId, UseLicenseURL, ValidationURL, PartialProductKey,
+    LicenseStatus, GracePeriodRemaining, RemainingAppReArmCount, RemainingSkuReArmCount, TrustedTime
+    FROM SoftwareLicensingProduct
+    WHERE ApplicationID = '55c92734-d682-4d71-983e-d6ec3f16059f'
+    AND PartialProductKey IS NOT NULL"
+
+    $candidates = @(Get-CimInstance -CimSession $CimSession -Query $query)
+
+    if ($candidates.Count -eq 0)
+    {
+        throw 'No Windows licensing product with an installed product key was found. The system may be running an evaluation edition or have no key installed.'
+    }
+
+    if ($candidates.Count -eq 1)
+    {
+        return $candidates[0]
+    }
+
+    # Multiple products can appear after in-place upgrades. Prefer Licensed, then any active state.
+    $licensed = @($candidates | Where-Object { $_.LicenseStatus -eq 1 })
+    if ($licensed.Count -eq 1) { return $licensed[0] }
+
+    $active = @($candidates | Where-Object { $_.LicenseStatus -ne 0 })
+    if ($active.Count -eq 1) { return $active[0] }
+
+    $summary = ($candidates | ForEach-Object { "'$($_.Name)' (status $($_.LicenseStatus))" }) -join ', '
+    throw "Multiple Windows licensing products found and none can be selected unambiguously: $summary. Use -ActivationId to target a specific product."
+}

--- a/src/Private/Invoke-KMSActivation.ps1
+++ b/src/Private/Invoke-KMSActivation.ps1
@@ -9,48 +9,53 @@ function Invoke-KMSActivation
     )
 
     # Check Windows Activation Status
-    $status = (Get-LicenseStatus -CimSession $CimSession).LicenseStatus
-    Write-Verbose "License Status: $($status)"
-    if ($status.Activated) { Write-Warning 'The product is already activated.'; return; }
+    $licenseInfo = Get-LicenseStatus -CimSession $CimSession
+    Write-Verbose "License Status: $($licenseInfo.'License Status')"
+    if ($licenseInfo.Activated) { Write-Warning 'The product is already activated.'; return; }
 
     # Get product key
     $productKey = Get-KMSKey -CimSession $CimSession
     Write-Verbose "Product Key (for KMS): $productKey"
 
-    # Activate Windows
     if ($productKey -eq 'Unknown')
     {
         throw 'Unknown OS.'
     }
     else
     {
-        # If provided, u[date values for Server FQDN and Port
+        # If provided, update values for Server FQDN and Port
         if ($PSBoundParameters.ContainsKey('KMSServerFQDN'))
         {
-            $service | Invoke-CimMethod -MethodName SetKeyManagementServiceMachine -Arguments @{ MachineName = $KeyServerPort }
+            $Service | Invoke-CimMethod -MethodName SetKeyManagementServiceMachine -Arguments @{ MachineName = $KMSServerFQDN } | Out-Null
         }
-        if ($PSBoundParameters.ContainsKey('KeyServerPort'))
+        if ($PSBoundParameters.ContainsKey('KMSServerPort'))
         {
-            $service | Invoke-CimMethod -MethodName SetKeyManagementServicePort -Arguments @{ PortNumber = $KeyServerPort }
+            $Service | Invoke-CimMethod -MethodName SetKeyManagementServicePort -Arguments @{ PortNumber = $KMSServerPort } | Out-Null
         }
 
-        $service | Invoke-CimMethod -MethodName InstallProductKey -Arguments @{ $ProductKey = $ProductKey } | Out-Null
+        $Service | Invoke-CimMethod -MethodName InstallProductKey -Arguments @{ ProductKey = $productKey } | Out-Null
 
         Start-Sleep -Seconds 10 # Installing product key takes time.
-        $service | Invoke-CimMethod -MethodName RefreshLicenseStatus | Out-Null
-        Start-Sleep -Seconds 2 # It also takes time.
+        $Service | Invoke-CimMethod -MethodName RefreshLicenseStatus | Out-Null
+        Start-Sleep -Seconds 2
 
+        # Trigger KMS network check-in via SoftwareLicensingProduct.Activate()
+        $activationQuery = 'SELECT ID, LicenseStatus, Name
+        FROM SoftwareLicensingProduct
+        WHERE LicenseStatus <> 0 AND Name LIKE "Windows%"'
+        $product = Get-CimInstance -CimSession $CimSession -Query $activationQuery | Select-Object -First 1
+        $product | Invoke-CimMethod -MethodName Activate | Out-Null
 
         # Check Windows Activation Status
         $license = Get-LicenseStatus -CimSession $CimSession
 
         if ($license.Activated)
         {
-            Write-Verbose "The computer activated succesfully. Current status: $($license.LicenseStatus)"
+            Write-Verbose "The computer activated successfully. Current status: $($license.'License Status')"
         }
         else
         {
-            throw "Activation failed. Current status: $($license.LicenseStatus)"
+            throw "Activation failed. Current status: $($license.'License Status')"
         }
     }
 }

--- a/src/Private/Invoke-KMSActivation.ps1
+++ b/src/Private/Invoke-KMSActivation.ps1
@@ -5,57 +5,49 @@ function Invoke-KMSActivation
         [Microsoft.Management.Infrastructure.CimSession]$CimSession,
         [CimInstance]$Service,
         [string]$KMSServerFQDN,
-        [int]$KMSServerPort
+        [int]$KMSServerPort,
+        [switch]$InstallKmsClientKey
     )
 
-    # Check Windows Activation Status
     $licenseInfo = Get-LicenseStatus -CimSession $CimSession
-    Write-Verbose "License Status: $($licenseInfo.'License Status')"
-    if ($licenseInfo.Activated) { Write-Warning 'The product is already activated.'; return; }
+    Write-Verbose "License Status: $($licenseInfo.LicenseStatus)"
+    if ($licenseInfo.Activated) { Write-Warning 'The product is already activated.'; return }
 
-    # Get product key
-    $productKey = Get-KMSKey -CimSession $CimSession
-    Write-Verbose "Product Key (for KMS): $productKey"
-
-    if ($productKey -eq 'Unknown')
+    if ($PSBoundParameters.ContainsKey('KMSServerFQDN'))
     {
-        throw 'Unknown OS.'
+        $Service | Invoke-SppCimMethod -MethodName SetKeyManagementServiceMachine -Arguments @{ MachineName = $KMSServerFQDN }
+    }
+    if ($PSBoundParameters.ContainsKey('KMSServerPort'))
+    {
+        $Service | Invoke-SppCimMethod -MethodName SetKeyManagementServicePort -Arguments @{ PortNumber = $KMSServerPort }
+    }
+
+    if ($InstallKmsClientKey.IsPresent)
+    {
+        $productKey = Get-KMSKey -CimSession $CimSession
+        if ($productKey -eq 'Unknown')
+        {
+            throw 'No KMS client setup key is available for this OS edition. Provide a product key manually or use a recognised edition.'
+        }
+        Write-Verbose 'Installing KMS client setup key'
+        $Service | Invoke-SppCimMethod -MethodName InstallProductKey -Arguments @{ ProductKey = $productKey }
+        Start-Sleep -Seconds 10 # Installing product key takes time.
+        $Service | Invoke-SppCimMethod -MethodName RefreshLicenseStatus
+        Start-Sleep -Seconds 2
+    }
+
+    # Trigger KMS network check-in via SoftwareLicensingProduct.Activate()
+    $product = Get-WindowsLicensingProduct -CimSession $CimSession
+    $product | Invoke-SppCimMethod -MethodName Activate
+    $Service | Invoke-SppCimMethod -MethodName RefreshLicenseStatus
+
+    $license = Get-LicenseStatus -CimSession $CimSession
+    if ($license.Activated)
+    {
+        Write-Verbose "The computer activated successfully. Current status: $($license.LicenseStatus)"
     }
     else
     {
-        # If provided, update values for Server FQDN and Port
-        if ($PSBoundParameters.ContainsKey('KMSServerFQDN'))
-        {
-            $Service | Invoke-CimMethod -MethodName SetKeyManagementServiceMachine -Arguments @{ MachineName = $KMSServerFQDN } | Out-Null
-        }
-        if ($PSBoundParameters.ContainsKey('KMSServerPort'))
-        {
-            $Service | Invoke-CimMethod -MethodName SetKeyManagementServicePort -Arguments @{ PortNumber = $KMSServerPort } | Out-Null
-        }
-
-        $Service | Invoke-CimMethod -MethodName InstallProductKey -Arguments @{ ProductKey = $productKey } | Out-Null
-
-        Start-Sleep -Seconds 10 # Installing product key takes time.
-        $Service | Invoke-CimMethod -MethodName RefreshLicenseStatus | Out-Null
-        Start-Sleep -Seconds 2
-
-        # Trigger KMS network check-in via SoftwareLicensingProduct.Activate()
-        $activationQuery = 'SELECT ID, LicenseStatus, Name
-        FROM SoftwareLicensingProduct
-        WHERE LicenseStatus <> 0 AND Name LIKE "Windows%"'
-        $product = Get-CimInstance -CimSession $CimSession -Query $activationQuery | Select-Object -First 1
-        $product | Invoke-CimMethod -MethodName Activate | Out-Null
-
-        # Check Windows Activation Status
-        $license = Get-LicenseStatus -CimSession $CimSession
-
-        if ($license.Activated)
-        {
-            Write-Verbose "The computer activated successfully. Current status: $($license.'License Status')"
-        }
-        else
-        {
-            throw "Activation failed. Current status: $($license.'License Status')"
-        }
+        throw "Activation failed. Current status: $($license.LicenseStatus)"
     }
 }

--- a/src/Private/Invoke-KMSActivation.ps1
+++ b/src/Private/Invoke-KMSActivation.ps1
@@ -16,8 +16,12 @@ function Invoke-KMSActivation
     if ($PSBoundParameters.ContainsKey('KMSServerFQDN'))
     {
         $Service | Invoke-SppCimMethod -MethodName SetKeyManagementServiceMachine -Arguments @{ MachineName = $KMSServerFQDN }
+        # Always set the port when changing the FQDN: without this, a stale non-default port
+        # from a previous call would be reused, silently targeting the wrong endpoint.
+        $effectivePort = if ($PSBoundParameters.ContainsKey('KMSServerPort')) { $KMSServerPort } else { 1688 }
+        $Service | Invoke-SppCimMethod -MethodName SetKeyManagementServicePort -Arguments @{ PortNumber = $effectivePort }
     }
-    if ($PSBoundParameters.ContainsKey('KMSServerPort'))
+    elseif ($PSBoundParameters.ContainsKey('KMSServerPort'))
     {
         $Service | Invoke-SppCimMethod -MethodName SetKeyManagementServicePort -Arguments @{ PortNumber = $KMSServerPort }
     }

--- a/src/Private/Invoke-OfflineActivation.ps1
+++ b/src/Private/Invoke-OfflineActivation.ps1
@@ -8,34 +8,32 @@ function Invoke-OfflineActivation
     )
 
     # Check Windows Activation Status
-    $status = (Get-LicenseStatus -CimSession $CimSession).LicenseStatus
-    Write-Verbose "License Status: $($status)"
-    if ($status.Activated) { Write-Warning 'The product is already activated.'; return; }
+    $licenseInfo = Get-LicenseStatus -CimSession $CimSession
+    Write-Verbose "License Status: $($licenseInfo.'License Status')"
+    if ($licenseInfo.Activated) { Write-Warning 'The product is already activated.'; return; }
 
     $query = 'SELECT ID, Name, PartialProductKey
     FROM SoftwareLicensingProduct
-    WHERE (PartialProductKey <> null AND Name LIKE "Windows%")'
+    WHERE (PartialProductKey IS NOT NULL AND Name LIKE "Windows%")'
 
     Write-Verbose 'Connecting to computer...'
-    $product = Get-CimInstance -CimSession $CimSession -Query $query
+    $product = Get-CimInstance -CimSession $CimSession -Query $query | Select-Object -First 1
 
     $InstallationId = (Get-OfflineInstallationId -CimSession $CimSession).'Offline Installation Id'
     Write-Verbose 'Submitting activation and confirmation IDs...'
-    Write-Debug 'Offline Installation ID: $InstallationId'
-    Write-Debug 'Confirmation ID: $ConfirmationId'
+    Write-Debug "Offline Installation ID: $InstallationId"
+    Write-Debug "Confirmation ID: $ConfirmationId"
 
     $arguments = @{
         InstallationId = $InstallationId
         ConfirmationId = $ConfirmationId
     }
 
-    try
+    if (($product | Invoke-CimMethod -MethodName DepositOfflineConfirmationId -Arguments $arguments).ReturnValue -ne 0)
     {
-        if ($(($product | Invoke-CimMethod -MethodName DepositOfflineConfirmationId -Arguments $arguments)).ReturnValue -ne 0)
-        { throw 'Failed to activate with offline activation. Check the Confirmation ID.' }
+        throw 'Failed to activate with offline activation. Check the Confirmation ID.'
     }
-    catch { throw }
 
     Write-Verbose 'Updating the license status...'
-    $Service | Invoke-CimMethod -MethodName RefreshLicenseStatus
+    $Service | Invoke-CimMethod -MethodName RefreshLicenseStatus | Out-Null
 }

--- a/src/Private/Invoke-OfflineActivation.ps1
+++ b/src/Private/Invoke-OfflineActivation.ps1
@@ -7,33 +7,25 @@ function Invoke-OfflineActivation
         [CimInstance]$Service
     )
 
-    # Check Windows Activation Status
     $licenseInfo = Get-LicenseStatus -CimSession $CimSession
-    Write-Verbose "License Status: $($licenseInfo.'License Status')"
-    if ($licenseInfo.Activated) { Write-Warning 'The product is already activated.'; return; }
+    Write-Verbose "License Status: $($licenseInfo.LicenseStatus)"
+    if ($licenseInfo.Activated) { Write-Warning 'The product is already activated.'; return }
 
-    $query = 'SELECT ID, Name, PartialProductKey
-    FROM SoftwareLicensingProduct
-    WHERE (PartialProductKey IS NOT NULL AND Name LIKE "Windows%")'
+    $product = Get-WindowsLicensingProduct -CimSession $CimSession
 
-    Write-Verbose 'Connecting to computer...'
-    $product = Get-CimInstance -CimSession $CimSession -Query $query | Select-Object -First 1
+    # Accept dashes, spaces, or plain digits; strip separators before submission
+    $normalizedCid = $ConfirmationId -replace '[\s\-]', ''
+    $installationId = (Get-OfflineInstallationId -CimSession $CimSession).OfflineInstallationId
 
-    $InstallationId = (Get-OfflineInstallationId -CimSession $CimSession).'Offline Installation Id'
     Write-Verbose 'Submitting activation and confirmation IDs...'
-    Write-Debug "Offline Installation ID: $InstallationId"
-    Write-Debug "Confirmation ID: $ConfirmationId"
+    Write-Debug "Offline Installation ID: $installationId"
+    Write-Debug "Confirmation ID: $normalizedCid"
 
-    $arguments = @{
-        InstallationId = $InstallationId
-        ConfirmationId = $ConfirmationId
-    }
-
-    if (($product | Invoke-CimMethod -MethodName DepositOfflineConfirmationId -Arguments $arguments).ReturnValue -ne 0)
-    {
-        throw 'Failed to activate with offline activation. Check the Confirmation ID.'
+    $product | Invoke-SppCimMethod -MethodName DepositOfflineConfirmationId -Arguments @{
+        InstallationId = $installationId
+        ConfirmationId = $normalizedCid
     }
 
     Write-Verbose 'Updating the license status...'
-    $Service | Invoke-CimMethod -MethodName RefreshLicenseStatus | Out-Null
+    $Service | Invoke-SppCimMethod -MethodName RefreshLicenseStatus
 }

--- a/src/Private/Invoke-Rearm.ps1
+++ b/src/Private/Invoke-Rearm.ps1
@@ -7,40 +7,31 @@ function Invoke-Rearm
     )
 
     $licenseInfo = Get-LicenseStatus -CimSession $CimSession
-    $status = $licenseInfo.'License Status'
+    $status = $licenseInfo.LicenseStatus
     if ($null -eq $status)
     {
-        throw 'License status cannot be collected. It is suggested to restart computer.'
+        throw 'License status cannot be collected. It is suggested to restart the computer.'
     }
 
     Write-Verbose "Current license status: $status"
 
-    # Rearm is only meaningful for grace/non-genuine states, not Licensed or Notification
-    $rearmableStatuses = @([LicenseStatusCode]::OOBGrace,
+    # Rearm is only meaningful for grace and non-genuine states
+    $rearmableStatuses = @(
+        [LicenseStatusCode]::OOBGrace,
         [LicenseStatusCode]::OOTGrace,
         [LicenseStatusCode]::NonGenuineGrace,
-        [LicenseStatusCode]::ExtendedGrace)
+        [LicenseStatusCode]::ExtendedGrace
+    )
     $isRearmable = $status -in $rearmableStatuses
     Write-Verbose "Is rearmable: $isRearmable"
 
-    if ($isRearmable -eq $false)
+    if (-not $isRearmable)
     {
         Write-Warning "Rearm is not applicable for the current license status: $status"
         return
     }
 
-    try
-    {
-        if ($($Service | Invoke-CimMethod -MethodName ReArmWindows).ReturnValue -ne 0)
-        {
-            throw 'Failed to rearm Windows.'
-        }
-        $Service | Invoke-CimMethod -MethodName RefreshLicenseStatus | Out-Null
-        Write-Verbose 'Command completed successfully.'
-        Write-Verbose 'Please restart the system for the changes to take effect.'
-    }
-    catch
-    {
-        throw
-    }
+    $Service | Invoke-SppCimMethod -MethodName ReArmWindows
+    $Service | Invoke-SppCimMethod -MethodName RefreshLicenseStatus
+    Write-Verbose 'Rearm completed. Please restart the system for the changes to take effect.'
 }

--- a/src/Private/Invoke-Rearm.ps1
+++ b/src/Private/Invoke-Rearm.ps1
@@ -6,17 +6,17 @@ function Invoke-Rearm
         [CimInstance]$Service
     )
 
-    $status = (Get-LicenseStatus -CimSession $CimSession).LicenseStatus
-    if ($status -eq [LicenseStatusCode]::Unknown)
+    $licenseInfo = Get-LicenseStatus -CimSession $CimSession
+    $status = $licenseInfo.'License Status'
+    if ($null -eq $status)
     {
         throw 'License status cannot be collected. It is suggested to restart computer.'
     }
 
     Write-Verbose "Current license status: $status"
 
-    # Any status except Unknown, Licensed and Notification
-    $rearmableStatuses = @([LicenseStatusCode]::Unlicensed,
-        [LicenseStatusCode]::OOBGrace,
+    # Rearm is only meaningful for grace/non-genuine states, not Licensed or Notification
+    $rearmableStatuses = @([LicenseStatusCode]::OOBGrace,
         [LicenseStatusCode]::OOTGrace,
         [LicenseStatusCode]::NonGenuineGrace,
         [LicenseStatusCode]::ExtendedGrace)
@@ -25,7 +25,7 @@ function Invoke-Rearm
 
     if ($isRearmable -eq $false)
     {
-        Write-Verbose 'No need to rearm.'
+        Write-Warning "Rearm is not applicable for the current license status: $status"
         return
     }
 

--- a/src/Private/Invoke-SppCimMethod.ps1
+++ b/src/Private/Invoke-SppCimMethod.ps1
@@ -1,0 +1,23 @@
+function Invoke-SppCimMethod
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [CimInstance]$InputObject,
+        [Parameter(Mandatory)]
+        [string]$MethodName,
+        [hashtable]$Arguments
+    )
+    Process
+    {
+        $invokeParams = @{ MethodName = $MethodName }
+        if ($PSBoundParameters.ContainsKey('Arguments')) { $invokeParams['Arguments'] = $Arguments }
+
+        $result = $InputObject | Invoke-CimMethod @invokeParams
+
+        if ($null -ne $result -and $result.ReturnValue -ne 0)
+        {
+            throw "${MethodName}: licensing operation failed (return value: $($result.ReturnValue))"
+        }
+    }
+}

--- a/src/Private/Invoke-SppCimMethod.ps1
+++ b/src/Private/Invoke-SppCimMethod.ps1
@@ -13,7 +13,7 @@ function Invoke-SppCimMethod
         $invokeParams = @{ MethodName = $MethodName }
         if ($PSBoundParameters.ContainsKey('Arguments')) { $invokeParams['Arguments'] = $Arguments }
 
-        $result = $InputObject | Invoke-CimMethod @invokeParams
+        $result = $InputObject | Invoke-CimMethod @invokeParams -ErrorAction Stop
 
         if ($null -ne $result -and $result.ReturnValue -ne 0)
         {

--- a/src/Public/Get-WindowsActivation.ps1
+++ b/src/Public/Get-WindowsActivation.ps1
@@ -27,9 +27,8 @@ https://github.com/zbalkan/slmgr-ps
 function Get-WindowsActivation
 {
     [OutputType([PSCustomObject])]
-    [CmdletBinding(SupportsShouldProcess = $true,
+    [CmdletBinding(
         PositionalBinding = $true,
-        ConfirmImpact = 'None',
         DefaultParameterSetName = 'Basic')]
     param(
         [Parameter(Mandatory = $false,
@@ -72,18 +71,17 @@ function Get-WindowsActivation
         $PreviousPreference = $ErrorActionPreference
         $ErrorActionPreference = 'Stop'
         Write-Verbose 'ErrorActionPreference: Stop'
+        $results = [System.Collections.Generic.List[PSCustomObject]]::new()
     }
     Process
     {
-        if ($pscmdlet.ShouldProcess($Computer -join ', ', 'Collect license information'))
+        Write-Verbose "Enumerating computers: $($Computer.Count) computer(s)."
+        foreach ($c in $Computer)
         {
-            $results = [System.Collections.Generic.List[PSCustomObject]]::new()
-            Write-Verbose "Enumerating computers: $($Computer.Count) computer(s)."
-            foreach ($c in $Computer)
+            Write-Verbose "Creating new CimSession for computer $c"
+            $session = Get-Session -Computer $c -Credentials $Credentials
+            try
             {
-                Write-Verbose "Creating new CimSession for computer $c"
-                $session = Get-Session -Computer $c -Credentials $Credentials
-
                 switch ($PSCmdlet.ParameterSetName)
                 {
                     'Extended'
@@ -103,18 +101,20 @@ function Get-WindowsActivation
                         $result = Get-BasicLicenseInformation -CimSession $session
                     }
                 }
+                $results.Add($result)
+            }
+            finally
+            {
                 if ($null -ne $session)
                 {
                     Remove-CimSession -CimSession $session -ErrorAction Ignore | Out-Null
                 }
-                $results.Add($result)
             }
-
-            return $results.ToArray()
         }
-        End
-        {
-            $ErrorActionPreference = $PreviousPreference
-        }
+    }
+    End
+    {
+        $ErrorActionPreference = $PreviousPreference
+        return $results.ToArray()
     }
 }

--- a/src/Public/Start-WindowsActivation.ps1
+++ b/src/Public/Start-WindowsActivation.ps1
@@ -15,13 +15,13 @@ Start-WindowsActivation -Verbose # Activates the local computer
 .EXAMPLE
 Start-WindowsActivation -Computer WS01 -Credentials (Get-Credential) # Activates the computer named WS01 using different credentials
 .EXAMPLE
-Start-WindowsActivation -Computer WS01, WS02 -CacheDisabled $false # Disabled the KMS cache for the computers named WS01 and WS02. Cache is enabled by default.
+Start-WindowsActivation -Computer WS01, WS02 -CacheDisabled # Disables the KMS cache for the computers named WS01 and WS02. Cache is enabled by default.
 .EXAMPLE
 Start-WindowsActivation -Computer WS01 -KMSServerFQDN server.domain.net -KMSServerPort 2500 # Activates the computer named WS01 against server.domain.net:2500
 .EXAMPLE
 Start-WindowsActivation -ReArm # ReArm the trial period. ReArming already licensed devices can break current license issues. Guard clauses wil protect 99% but cannot guarantee 100%.
 .EXAMPLE
-Start-WindowsActivation -Offline -ConfirmationID <confirmation ID> # Used for offline -aka phone- activation
+Start-WindowsActivation -Offline -ConfirmationID 123456-123456-123456-123456-123456-123456-123456-123456-123456 # Used for offline -aka phone- activation
 .LINK
 https://github.com/zbalkan/slmgr-ps
 #>
@@ -60,8 +60,8 @@ function Start-WindowsActivation
 
         [Parameter(Mandatory = $false,
             Position = 1,
-            ValueFromPipeline = $true,
-            ValueFromPipelineByPropertyName = $true,
+            ValueFromPipeline = $false,
+            ValueFromPipelineByPropertyName = $false,
             ValueFromRemainingArguments = $false,
             ParameterSetName = 'ActivateWithKMS')]
         [ValidateLength(6, 253)]
@@ -83,8 +83,8 @@ function Start-WindowsActivation
 
         [Parameter(Mandatory = $false,
             Position = 2,
-            ValueFromPipeline = $true,
-            ValueFromPipelineByPropertyName = $true,
+            ValueFromPipeline = $false,
+            ValueFromPipelineByPropertyName = $false,
             ValueFromRemainingArguments = $false,
             ParameterSetName = 'ActivateWithKMS')]
         [ValidateRange(1, 65535)]
@@ -119,17 +119,17 @@ function Start-WindowsActivation
             ValueFromPipelineByPropertyName = $false,
             ValueFromRemainingArguments = $false,
             ParameterSetName = 'Offline')]
-        [ValidateLength(64, 64)]
         [ValidateScript(
             {
-                $pattern = [Regex]::new('^[0-9]{64}$')
+                # Standard Windows phone activation CID: 9 groups of 6 digits separated by dashes
+                $pattern = [Regex]::new('^\d{6}(-\d{6}){8}$')
                 if ($pattern.Matches($_).Count -gt 0)
                 {
                     $true
                 }
                 else
                 {
-                    throw "$_ is invalid. Please provide a valid Confirmation Id"
+                    throw "$_ is invalid. Please provide a valid Confirmation Id (9 groups of 6 digits separated by dashes)"
                 }
             })]
         [ValidateNotNullOrEmpty()]
@@ -151,41 +151,45 @@ function Start-WindowsActivation
             foreach ($c in $Computer)
             {
                 Write-Verbose "Creating new CimSession for computer $c"
-                $session = Get-Session -Computer $c -Credentials $Credentials
-
-                Write-Verbose 'Connecting to SoftwareLicensingService..'
-                $service = Get-CimInstance -CimSession $session -ClassName SoftwareLicensingService
-
+                $session = $null
                 try
                 {
+                    $session = Get-Session -Computer $c -Credentials $Credentials
+
+                    Write-Verbose 'Connecting to SoftwareLicensingService...'
+                    $service = Get-CimInstance -CimSession $session -ClassName SoftwareLicensingService
+
                     switch ($PSCmdlet.ParameterSetName)
                     {
                         'Offline'
                         {
                             Write-Verbose 'Initiating offline activation operation'
-                            Invoke-OfflineActivation -CimSession $session -Service $service -$ConfirmationId
-                            exit 0
+                            Invoke-OfflineActivation -CimSession $session -Service $service -ConfirmationId $ConfirmationId
                         }
 
                         'Rearm'
                         {
                             Write-Verbose 'Initiating ReArm operation'
                             Invoke-Rearm -CimSession $session -Service $service
-                            exit 0
                         }
 
                         'ActivateWithKMS'
                         {
-                            Write-Verbose "Changing KMS cache setting as: $($CacheDisabled.IsPresent -eq $false)"
                             if ($CacheDisabled.IsPresent)
                             {
-                                $arguments = @{ DisableCaching = 1 }
-                                $Service | Invoke-CimMethod -MethodName DisableKeyManagementServiceHostCaching -Arguments $arguments | Out-Null # Disable caching
+                                Write-Verbose 'Disabling KMS cache'
+                                $service | Invoke-CimMethod -MethodName DisableKeyManagementServiceHostCaching | Out-Null
+                            }
+                            else
+                            {
+                                Write-Verbose 'KMS cache: leaving enabled'
                             }
 
                             Write-Verbose 'Initiating KMS activation operation'
-                            Invoke-KMSActivation $PSBoundParameters -CimSession $session -Service $service
-                            exit 0
+                            $kmsParams = @{ CimSession = $session; Service = $service }
+                            if ($PSBoundParameters.ContainsKey('KMSServerFQDN')) { $kmsParams['KMSServerFQDN'] = $KMSServerFQDN }
+                            if ($PSBoundParameters.ContainsKey('KMSServerPort')) { $kmsParams['KMSServerPort'] = $KMSServerPort }
+                            Invoke-KMSActivation @kmsParams
                         }
 
                         default
@@ -193,18 +197,17 @@ function Start-WindowsActivation
                             throw 'Unknown parameter combination' # We do not expect this to be triggered at all but it is here to prevent human errors
                         }
                     }
-                    if ($null -ne $session)
-                    {
-                        Remove-CimSession -CimSession $session -ErrorAction Ignore | Out-Null
-                    }
                 }
                 catch
+                {
+                    throw
+                }
+                finally
                 {
                     if ($null -ne $session)
                     {
                         Remove-CimSession -CimSession $session -ErrorAction Ignore | Out-Null
                     }
-                    exit 1
                 }
             }
         }

--- a/src/Public/Start-WindowsActivation.ps1
+++ b/src/Public/Start-WindowsActivation.ps1
@@ -5,23 +5,28 @@
 .Synopsis
 Activates Windows via KMS
 .DESCRIPTION
-A drop in replacement for slmgr script
+A drop in replacement for slmgr script. By default attempts KMS activation using the
+product key already installed on the machine. Use -UseKmsClientKey to also install the
+KMS client setup key (GVLK) for the detected OS edition before activating. This is a
+material licensing change and is therefore opt-in.
 .INPUTS
 string[]. You can pass the computer names
 .OUTPUTS
-None if successful. Error message if there is an error.
+None if successful. Throws on error.
 .EXAMPLE
-Start-WindowsActivation -Verbose # Activates the local computer
+Start-WindowsActivation -Verbose # Activates the local computer using its existing product key
 .EXAMPLE
-Start-WindowsActivation -Computer WS01 -Credentials (Get-Credential) # Activates the computer named WS01 using different credentials
+Start-WindowsActivation -UseKmsClientKey -Verbose # Installs the GVLK for the detected OS edition then activates
 .EXAMPLE
-Start-WindowsActivation -Computer WS01, WS02 -CacheDisabled # Disables the KMS cache for the computers named WS01 and WS02. Cache is enabled by default.
+Start-WindowsActivation -Computer WS01 -Credentials (Get-Credential) # Activates WS01 over WinRM
 .EXAMPLE
-Start-WindowsActivation -Computer WS01 -KMSServerFQDN server.domain.net -KMSServerPort 2500 # Activates the computer named WS01 against server.domain.net:2500
+Start-WindowsActivation -Computer WS01, WS02 -CacheDisabled # Disables the KMS cache on WS01 and WS02
 .EXAMPLE
-Start-WindowsActivation -ReArm # ReArm the trial period. ReArming already licensed devices can break current license issues. Guard clauses wil protect 99% but cannot guarantee 100%.
+Start-WindowsActivation -Computer WS01 -KMSServerFQDN server.domain.net -KMSServerPort 2500 # Activates against a specific KMS server
 .EXAMPLE
-Start-WindowsActivation -Offline -ConfirmationID 123456-123456-123456-123456-123456-123456-123456-123456-123456 # Used for offline -aka phone- activation
+Start-WindowsActivation -ReArm # ReArm the trial period (guard clauses apply but cannot guarantee 100% safety)
+.EXAMPLE
+Start-WindowsActivation -Offline -ConfirmationID 123456-123456-123456-123456-123456-123456-123456-123456-123456 # Phone activation
 .LINK
 https://github.com/zbalkan/slmgr-ps
 #>
@@ -107,6 +112,17 @@ function Start-WindowsActivation
         [switch]
         $CacheDisabled,
 
+        # Installs the KMS client setup key (GVLK) for the detected OS edition before
+        # attempting activation. Only needed when the machine currently has a MAK or retail
+        # key and must be switched to volume/KMS licensing. This is a material licensing change.
+        [Parameter(Mandatory = $false,
+            ValueFromPipeline = $false,
+            ValueFromPipelineByPropertyName = $false,
+            ValueFromRemainingArguments = $false,
+            ParameterSetName = 'ActivateWithKMS')]
+        [switch]
+        $UseKmsClientKey,
+
         [Parameter(Mandatory = $false,
             ValueFromPipeline = $false,
             ValueFromPipelineByPropertyName = $false,
@@ -121,15 +137,15 @@ function Start-WindowsActivation
             ParameterSetName = 'Offline')]
         [ValidateScript(
             {
-                # Standard Windows phone activation CID: 9 groups of 6 digits separated by dashes
-                $pattern = [Regex]::new('^\d{6}(-\d{6}){8}$')
-                if ($pattern.Matches($_).Count -gt 0)
+                # Accept 54 digits (9 groups × 6), optionally separated by dashes or spaces
+                $stripped = $_ -replace '[\s\-]', ''
+                if ($stripped -match '^\d{54}$')
                 {
                     $true
                 }
                 else
                 {
-                    throw "$_ is invalid. Please provide a valid Confirmation Id (9 groups of 6 digits separated by dashes)"
+                    throw "$_ is not a valid Confirmation ID. Expected 54 digits (9 groups of 6), optionally separated by dashes or spaces."
                 }
             })]
         [ValidateNotNullOrEmpty()]
@@ -145,69 +161,68 @@ function Start-WindowsActivation
     }
     Process
     {
-        if ($pscmdlet.ShouldProcess($Computer -join ', ', 'Activate license via KMS'))
+        Write-Verbose "Enumerating computers: $($Computer.Count) computer(s)."
+        foreach ($c in $Computer)
         {
-            Write-Verbose "Enumerating computers: $($Computer.Count) computer(s)."
-            foreach ($c in $Computer)
+            if (-not $pscmdlet.ShouldProcess($c, "Activate Windows ($($PSCmdlet.ParameterSetName))"))
             {
-                Write-Verbose "Creating new CimSession for computer $c"
-                $session = $null
-                try
+                continue
+            }
+
+            Write-Verbose "Creating new CimSession for computer $c"
+            $session = $null
+            try
+            {
+                $session = Get-Session -Computer $c -Credentials $Credentials
+
+                Write-Verbose 'Connecting to SoftwareLicensingService...'
+                $service = Get-CimInstance -CimSession $session -ClassName SoftwareLicensingService
+
+                switch ($PSCmdlet.ParameterSetName)
                 {
-                    $session = Get-Session -Computer $c -Credentials $Credentials
-
-                    Write-Verbose 'Connecting to SoftwareLicensingService...'
-                    $service = Get-CimInstance -CimSession $session -ClassName SoftwareLicensingService
-
-                    switch ($PSCmdlet.ParameterSetName)
+                    'Offline'
                     {
-                        'Offline'
+                        Write-Verbose 'Initiating offline activation operation'
+                        Invoke-OfflineActivation -CimSession $session -Service $service -ConfirmationId $ConfirmationId
+                    }
+
+                    'Rearm'
+                    {
+                        Write-Verbose 'Initiating ReArm operation'
+                        Invoke-Rearm -CimSession $session -Service $service
+                    }
+
+                    'ActivateWithKMS'
+                    {
+                        if ($CacheDisabled.IsPresent)
                         {
-                            Write-Verbose 'Initiating offline activation operation'
-                            Invoke-OfflineActivation -CimSession $session -Service $service -ConfirmationId $ConfirmationId
+                            Write-Verbose 'Disabling KMS host caching'
+                            $service | Invoke-SppCimMethod -MethodName DisableKeyManagementServiceHostCaching
                         }
 
-                        'Rearm'
-                        {
-                            Write-Verbose 'Initiating ReArm operation'
-                            Invoke-Rearm -CimSession $session -Service $service
-                        }
+                        Write-Verbose 'Initiating KMS activation operation'
+                        $kmsParams = @{ CimSession = $session; Service = $service }
+                        if ($PSBoundParameters.ContainsKey('KMSServerFQDN')) { $kmsParams['KMSServerFQDN'] = $KMSServerFQDN }
+                        if ($PSBoundParameters.ContainsKey('KMSServerPort')) { $kmsParams['KMSServerPort'] = $KMSServerPort }
+                        if ($UseKmsClientKey.IsPresent) { $kmsParams['InstallKmsClientKey'] = $true }
+                        Invoke-KMSActivation @kmsParams
+                    }
 
-                        'ActivateWithKMS'
-                        {
-                            if ($CacheDisabled.IsPresent)
-                            {
-                                Write-Verbose 'Disabling KMS cache'
-                                $service | Invoke-CimMethod -MethodName DisableKeyManagementServiceHostCaching | Out-Null
-                            }
-                            else
-                            {
-                                Write-Verbose 'KMS cache: leaving enabled'
-                            }
-
-                            Write-Verbose 'Initiating KMS activation operation'
-                            $kmsParams = @{ CimSession = $session; Service = $service }
-                            if ($PSBoundParameters.ContainsKey('KMSServerFQDN')) { $kmsParams['KMSServerFQDN'] = $KMSServerFQDN }
-                            if ($PSBoundParameters.ContainsKey('KMSServerPort')) { $kmsParams['KMSServerPort'] = $KMSServerPort }
-                            Invoke-KMSActivation @kmsParams
-                        }
-
-                        default
-                        {
-                            throw 'Unknown parameter combination' # We do not expect this to be triggered at all but it is here to prevent human errors
-                        }
+                    default
+                    {
+                        throw 'Unknown parameter combination'
                     }
                 }
-                catch
+            }
+            catch
+            {
+                throw
+            }
+            finally
+            {
+                if ($null -ne $session)
                 {
-                    throw
-                }
-                finally
-                {
-                    if ($null -ne $session)
-                    {
-                        Remove-CimSession -CimSession $session -ErrorAction Ignore | Out-Null
-                    }
+                    Remove-CimSession -CimSession $session -ErrorAction Ignore | Out-Null
                 }
             }
         }

--- a/src/slmgr-ps.psd1
+++ b/src/slmgr-ps.psd1
@@ -69,16 +69,16 @@
     # NestedModules = @()
 
     # Functions to export from this module
-    FunctionsToExport = '*'
+    FunctionsToExport = @('Get-WindowsActivation', 'Start-WindowsActivation')
 
     # Cmdlets to export from this module
-    CmdletsToExport   = '*'
+    CmdletsToExport   = @()
 
     # Variables to export from this module
-    VariablesToExport = '*'
+    VariablesToExport = @()
 
     # Aliases to export from this module
-    AliasesToExport   = '*'
+    AliasesToExport   = @()
 
     # DSC resources to export from this module
     # DscResourcesToExport = @()

--- a/src/slmgr-ps.psm1
+++ b/src/slmgr-ps.psm1
@@ -1,9 +1,9 @@
 #Get public and private function definition files.
-$Public = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -ErrorAction SilentlyContinue )
+$Public  = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1  -ErrorAction SilentlyContinue )
 $Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue )
 
-#Dot source the files
-Foreach ($import in @($Public + $Private))
+#Dot source the files - Private first so enums and helpers are available when Public files load
+Foreach ($import in @($Private + $Public))
 {
     Try
     {
@@ -11,13 +11,8 @@ Foreach ($import in @($Public + $Private))
     }
     Catch
     {
-        Write-Error -Message "Failed to import function $($import.fullname): $_"
+        throw "Failed to import function $($import.fullname): $_"
     }
 }
-
-# Here I might...
-# Read in or create an initial config file and variable
-# Export Public functions ($Public.BaseName) for WIP modules
-# Set variables visible to the module and its functions only
 
 Export-ModuleMember -Function $Public.Basename

--- a/tests/Get-ExpiryInformation.Tests.ps1
+++ b/tests/Get-ExpiryInformation.Tests.ps1
@@ -1,0 +1,89 @@
+BeforeAll {
+    . $PSScriptRoot/../src/Private/LicenseStatusCode.ps1
+    . $PSScriptRoot/../src/Private/Get-WindowsLicensingProduct.ps1
+    . $PSScriptRoot/../src/Private/Get-ExpiryInformation.ps1
+}
+
+Describe 'Get-ExpiryInformation' {
+
+    It 'Reports permanent activation when Licensed with no grace remaining' {
+        Mock Get-WindowsLicensingProduct {
+            [PSCustomObject]@{
+                Name                = 'Windows 11 Pro'
+                LicenseStatus       = 1
+                GracePeriodRemaining = 0
+                Description         = 'Volume:GVLK'
+            }
+        }
+        $result = Get-ExpiryInformation -CimSession $null
+        $result.ExpirationInfo | Should -Be 'The machine is permanently activated.'
+    }
+
+    It 'Reports permanent activation when Licensed with null grace' {
+        Mock Get-WindowsLicensingProduct {
+            [PSCustomObject]@{
+                Name                = 'Windows 11 Pro'
+                LicenseStatus       = 1
+                GracePeriodRemaining = $null
+                Description         = 'Volume:GVLK'
+            }
+        }
+        $result = Get-ExpiryInformation -CimSession $null
+        $result.ExpirationInfo | Should -Be 'The machine is permanently activated.'
+    }
+
+    It 'Reports timebased expiry for TIMEBASED_ description' {
+        Mock Get-WindowsLicensingProduct {
+            [PSCustomObject]@{
+                Name                = 'Windows 11 Pro'
+                LicenseStatus       = 1
+                GracePeriodRemaining = 43200
+                Description         = 'Volume:GVLK:TIMEBASED_'
+            }
+        }
+        $result = Get-ExpiryInformation -CimSession $null
+        $result.ExpirationInfo | Should -Match 'Timebased activation will expire'
+    }
+
+    It 'Reports VM activation expiry for VIRTUAL_MACHINE_ACTIVATION description' {
+        Mock Get-WindowsLicensingProduct {
+            [PSCustomObject]@{
+                Name                = 'Windows 11 Pro'
+                LicenseStatus       = 1
+                GracePeriodRemaining = 43200
+                Description         = 'Volume:GVLK:VIRTUAL_MACHINE_ACTIVATION'
+            }
+        }
+        $result = Get-ExpiryInformation -CimSession $null
+        $result.ExpirationInfo | Should -Match 'Automatic VM activation will expire'
+    }
+
+    It 'Reports OOBGrace end date when status is 2' {
+        Mock Get-WindowsLicensingProduct {
+            [PSCustomObject]@{
+                Name                = 'Windows 11 Pro'
+                LicenseStatus       = 2
+                GracePeriodRemaining = 43200
+                Description         = ''
+            }
+        }
+        $result = Get-ExpiryInformation -CimSession $null
+        $result.ExpirationInfo | Should -Match 'Initial grace period ends'
+    }
+
+    It 'Uses PascalCase property names' {
+        Mock Get-WindowsLicensingProduct {
+            [PSCustomObject]@{
+                Name                = 'Windows 11 Pro'
+                LicenseStatus       = 1
+                GracePeriodRemaining = 0
+                Description         = ''
+            }
+        }
+        $result = Get-ExpiryInformation -CimSession $null
+        $result.PSObject.Properties.Name | Should -Contain 'LicenseStatus'
+        $result.PSObject.Properties.Name | Should -Contain 'ExpirationInfo'
+        $result.PSObject.Properties.Name | Should -Not -Contain 'License Status'
+        $result.PSObject.Properties.Name | Should -Not -Contain 'Expiration Information'
+    }
+}

--- a/tests/Get-KMSKey.Tests.ps1
+++ b/tests/Get-KMSKey.Tests.ps1
@@ -1,102 +1,103 @@
 BeforeAll {
     . $PSScriptRoot/../src/Private/Get-KMSKey.ps1
+    $script:MockCimSession = New-MockObject -Type 'Microsoft.Management.Infrastructure.CimSession'
 }
 
 Describe 'Get-KMSKey' {
 
     It 'Returns correct key for Windows 11 Pro' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Pro' } }
-        Get-KMSKey -CimSession $null | Should -Be 'W269N-WFGWX-YVC9B-4J6C9-T83GX'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be 'W269N-WFGWX-YVC9B-4J6C9-T83GX'
     }
 
     It 'Returns correct key for Windows 11 Pro with trailing OS suffix' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Pro 24H2' } }
-        Get-KMSKey -CimSession $null | Should -Be 'W269N-WFGWX-YVC9B-4J6C9-T83GX'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be 'W269N-WFGWX-YVC9B-4J6C9-T83GX'
     }
 
     It 'Returns correct key for Windows 11 Pro N' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Pro N' } }
-        Get-KMSKey -CimSession $null | Should -Be 'MH37W-N47XK-V7XM9-C7227-GCQG9'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be 'MH37W-N47XK-V7XM9-C7227-GCQG9'
     }
 
     It 'Returns correct key for Windows 11 Enterprise' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Enterprise' } }
-        Get-KMSKey -CimSession $null | Should -Be 'NPPR9-FWDCX-D2C8J-H872K-2YT43'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be 'NPPR9-FWDCX-D2C8J-H872K-2YT43'
     }
 
     It 'Returns correct key for Windows 11 Enterprise N' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Enterprise N' } }
-        Get-KMSKey -CimSession $null | Should -Be 'DPH2V-TTNVB-4X9Q3-TJR4H-KHJW4'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be 'DPH2V-TTNVB-4X9Q3-TJR4H-KHJW4'
     }
 
     It 'Returns correct key for Windows 11 Enterprise LTSC' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Enterprise LTSC 2024' } }
-        Get-KMSKey -CimSession $null | Should -Be 'M7XTQ-FN8P6-TTKYV-9D4CC-J462D'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be 'M7XTQ-FN8P6-TTKYV-9D4CC-J462D'
     }
 
     It 'Returns correct key for Windows 11 Enterprise N LTSC' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Enterprise N LTSC 2024' } }
-        Get-KMSKey -CimSession $null | Should -Be '92NFX-8DJQP-P6BBQ-THF9C-7CG2H'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be '92NFX-8DJQP-P6BBQ-THF9C-7CG2H'
     }
 
     It 'Returns correct key for Windows 11 Education' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Education' } }
-        Get-KMSKey -CimSession $null | Should -Be 'NW6C2-QMPVW-D7KKK-3GKT6-VCFB2'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be 'NW6C2-QMPVW-D7KKK-3GKT6-VCFB2'
     }
 
     It 'Returns correct key for Windows 11 Education N' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Education N' } }
-        Get-KMSKey -CimSession $null | Should -Be '2WH4N-8QGBV-H22JP-CT43Q-MDWWJ'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be '2WH4N-8QGBV-H22JP-CT43Q-MDWWJ'
     }
 
     It 'Returns correct key for Windows 10 Enterprise LTSC' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 10 Enterprise LTSC' } }
-        Get-KMSKey -CimSession $null | Should -Be 'M7XTQ-FN8P6-TTKYV-9D4CC-J462D'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be 'M7XTQ-FN8P6-TTKYV-9D4CC-J462D'
     }
 
     It 'Returns correct key for Windows 10 Enterprise N LTSC' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 10 Enterprise N LTSC 2021' } }
-        Get-KMSKey -CimSession $null | Should -Be '92NFX-8DJQP-P6BBQ-THF9C-7CG2H'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be '92NFX-8DJQP-P6BBQ-THF9C-7CG2H'
     }
 
     It 'Returns correct key for Windows Server 2025 Standard' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows Server 2025 Standard' } }
-        Get-KMSKey -CimSession $null | Should -Be 'TVRH6-WHNXV-R9WG3-9XRFY-MY832'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be 'TVRH6-WHNXV-R9WG3-9XRFY-MY832'
     }
 
     It 'Returns correct key for Windows Server 2022 Datacenter Azure Edition' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows Server 2022 Datacenter: Azure Edition' } }
-        Get-KMSKey -CimSession $null | Should -Be 'NTBV8-9K7Q8-V27C6-M2BTV-KHMXV'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be 'NTBV8-9K7Q8-V27C6-M2BTV-KHMXV'
     }
 
     It 'Does not return Azure Edition key for plain Server 2022 Datacenter' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows Server 2022 Datacenter' } }
-        Get-KMSKey -CimSession $null | Should -Be 'WX4NM-KYWYW-QJJR4-XV3QB-6VM33'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be 'WX4NM-KYWYW-QJJR4-XV3QB-6VM33'
     }
 
     It 'Returns correct key for Windows Server 2025 Datacenter Azure Edition' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows Server 2025 Datacenter: Azure Edition' } }
-        Get-KMSKey -CimSession $null | Should -Be 'XGN3F-F394H-FD2MY-PP6FD-8MCRC'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be 'XGN3F-F394H-FD2MY-PP6FD-8MCRC'
     }
 
     It 'Returns correct key for Windows Server 2016 Standard' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows Server 2016 Standard' } }
-        Get-KMSKey -CimSession $null | Should -Be 'WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be 'WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY'
     }
 
     It 'Returns correct key for Windows Server 2016 Datacenter' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows Server 2016 Datacenter' } }
-        Get-KMSKey -CimSession $null | Should -Be 'CB7KF-BWN84-R7R2Y-793K2-8XDDG'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be 'CB7KF-BWN84-R7R2Y-793K2-8XDDG'
     }
 
     It 'Returns Unknown for unrecognised OS' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows XP Professional' } }
-        Get-KMSKey -CimSession $null | Should -Be 'Unknown'
+        Get-KMSKey -CimSession $script:MockCimSession | Should -Be 'Unknown'
     }
 
     It 'Enterprise N LTSC does not match plain Enterprise N pattern' {
         Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Enterprise N LTSC 2024' } }
-        $key = Get-KMSKey -CimSession $null
+        $key = Get-KMSKey -CimSession $script:MockCimSession
         $key | Should -Be '92NFX-8DJQP-P6BBQ-THF9C-7CG2H'
         $key | Should -Not -Be 'DPH2V-TTNVB-4X9Q3-TJR4H-KHJW4'
     }

--- a/tests/Get-KMSKey.Tests.ps1
+++ b/tests/Get-KMSKey.Tests.ps1
@@ -1,0 +1,103 @@
+BeforeAll {
+    . $PSScriptRoot/../src/Private/Get-KMSKey.ps1
+}
+
+Describe 'Get-KMSKey' {
+
+    It 'Returns correct key for Windows 11 Pro' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Pro' } }
+        Get-KMSKey -CimSession $null | Should -Be 'W269N-WFGWX-YVC9B-4J6C9-T83GX'
+    }
+
+    It 'Returns correct key for Windows 11 Pro with trailing OS suffix' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Pro 24H2' } }
+        Get-KMSKey -CimSession $null | Should -Be 'W269N-WFGWX-YVC9B-4J6C9-T83GX'
+    }
+
+    It 'Returns correct key for Windows 11 Pro N' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Pro N' } }
+        Get-KMSKey -CimSession $null | Should -Be 'MH37W-N47XK-V7XM9-C7227-GCQG9'
+    }
+
+    It 'Returns correct key for Windows 11 Enterprise' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Enterprise' } }
+        Get-KMSKey -CimSession $null | Should -Be 'NPPR9-FWDCX-D2C8J-H872K-2YT43'
+    }
+
+    It 'Returns correct key for Windows 11 Enterprise N' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Enterprise N' } }
+        Get-KMSKey -CimSession $null | Should -Be 'DPH2V-TTNVB-4X9Q3-TJR4H-KHJW4'
+    }
+
+    It 'Returns correct key for Windows 11 Enterprise LTSC' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Enterprise LTSC 2024' } }
+        Get-KMSKey -CimSession $null | Should -Be 'M7XTQ-FN8P6-TTKYV-9D4CC-J462D'
+    }
+
+    It 'Returns correct key for Windows 11 Enterprise N LTSC' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Enterprise N LTSC 2024' } }
+        Get-KMSKey -CimSession $null | Should -Be '92NFX-8DJQP-P6BBQ-THF9C-7CG2H'
+    }
+
+    It 'Returns correct key for Windows 11 Education' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Education' } }
+        Get-KMSKey -CimSession $null | Should -Be 'NW6C2-QMPVW-D7KKK-3GKT6-VCFB2'
+    }
+
+    It 'Returns correct key for Windows 11 Education N' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Education N' } }
+        Get-KMSKey -CimSession $null | Should -Be '2WH4N-8QGBV-H22JP-CT43Q-MDWWJ'
+    }
+
+    It 'Returns correct key for Windows 10 Enterprise LTSC' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 10 Enterprise LTSC' } }
+        Get-KMSKey -CimSession $null | Should -Be 'M7XTQ-FN8P6-TTKYV-9D4CC-J462D'
+    }
+
+    It 'Returns correct key for Windows 10 Enterprise N LTSC' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 10 Enterprise N LTSC 2021' } }
+        Get-KMSKey -CimSession $null | Should -Be '92NFX-8DJQP-P6BBQ-THF9C-7CG2H'
+    }
+
+    It 'Returns correct key for Windows Server 2025 Standard' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows Server 2025 Standard' } }
+        Get-KMSKey -CimSession $null | Should -Be 'TVRH6-WHNXV-R9WG3-9XRFY-MY832'
+    }
+
+    It 'Returns correct key for Windows Server 2022 Datacenter Azure Edition' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows Server 2022 Datacenter: Azure Edition' } }
+        Get-KMSKey -CimSession $null | Should -Be 'NTBV8-9K7Q8-V27C6-M2BTV-KHMXV'
+    }
+
+    It 'Does not return Azure Edition key for plain Server 2022 Datacenter' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows Server 2022 Datacenter' } }
+        Get-KMSKey -CimSession $null | Should -Be 'WX4NM-KYWYW-QJJR4-XV3QB-6VM33'
+    }
+
+    It 'Returns correct key for Windows Server 2025 Datacenter Azure Edition' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows Server 2025 Datacenter: Azure Edition' } }
+        Get-KMSKey -CimSession $null | Should -Be 'XGN3F-F394H-FD2MY-PP6FD-8MCRC'
+    }
+
+    It 'Returns correct key for Windows Server 2016 Standard' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows Server 2016 Standard' } }
+        Get-KMSKey -CimSession $null | Should -Be 'WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY'
+    }
+
+    It 'Returns correct key for Windows Server 2016 Datacenter' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows Server 2016 Datacenter' } }
+        Get-KMSKey -CimSession $null | Should -Be 'CB7KF-BWN84-R7R2Y-793K2-8XDDG'
+    }
+
+    It 'Returns Unknown for unrecognised OS' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows XP Professional' } }
+        Get-KMSKey -CimSession $null | Should -Be 'Unknown'
+    }
+
+    It 'Enterprise N LTSC does not match plain Enterprise N pattern' {
+        Mock Get-CimInstance { [PSCustomObject]@{ Caption = 'Microsoft Windows 11 Enterprise N LTSC 2024' } }
+        $key = Get-KMSKey -CimSession $null
+        $key | Should -Be '92NFX-8DJQP-P6BBQ-THF9C-7CG2H'
+        $key | Should -Not -Be 'DPH2V-TTNVB-4X9Q3-TJR4H-KHJW4'
+    }
+}

--- a/tests/Get-LicenseStatus.Tests.ps1
+++ b/tests/Get-LicenseStatus.Tests.ps1
@@ -1,0 +1,44 @@
+BeforeAll {
+    . $PSScriptRoot/../src/Private/LicenseStatusCode.ps1
+    . $PSScriptRoot/../src/Private/Get-WindowsLicensingProduct.ps1
+    . $PSScriptRoot/../src/Private/Get-LicenseStatus.ps1
+}
+
+Describe 'Get-LicenseStatus' {
+
+    It 'Returns Activated=true when LicenseStatus is Licensed (1)' {
+        Mock Get-WindowsLicensingProduct {
+            [PSCustomObject]@{ Name = 'Windows 11 Pro'; LicenseStatus = 1 }
+        }
+        $result = Get-LicenseStatus -CimSession $null
+        $result.Activated | Should -BeTrue
+        $result.LicenseStatus | Should -Be ([LicenseStatusCode]::Licensed)
+    }
+
+    It 'Returns Activated=false when LicenseStatus is OOBGrace (2)' {
+        Mock Get-WindowsLicensingProduct {
+            [PSCustomObject]@{ Name = 'Windows 11 Pro'; LicenseStatus = 2 }
+        }
+        $result = Get-LicenseStatus -CimSession $null
+        $result.Activated | Should -BeFalse
+        $result.LicenseStatus | Should -Be ([LicenseStatusCode]::OOBGrace)
+    }
+
+    It 'Returns Activated=false when LicenseStatus is Notification (5)' {
+        Mock Get-WindowsLicensingProduct {
+            [PSCustomObject]@{ Name = 'Windows 11 Pro'; LicenseStatus = 5 }
+        }
+        $result = Get-LicenseStatus -CimSession $null
+        $result.Activated | Should -BeFalse
+        $result.LicenseStatus | Should -Be ([LicenseStatusCode]::Notification)
+    }
+
+    It 'Exposes LicenseStatus property (not space-separated)' {
+        Mock Get-WindowsLicensingProduct {
+            [PSCustomObject]@{ Name = 'Windows 11 Pro'; LicenseStatus = 1 }
+        }
+        $result = Get-LicenseStatus -CimSession $null
+        $result.PSObject.Properties.Name | Should -Contain 'LicenseStatus'
+        $result.PSObject.Properties.Name | Should -Not -Contain 'License Status'
+    }
+}

--- a/tests/Get-WindowsLicensingProduct.Tests.ps1
+++ b/tests/Get-WindowsLicensingProduct.Tests.ps1
@@ -1,6 +1,7 @@
 BeforeAll {
     . $PSScriptRoot/../src/Private/LicenseStatusCode.ps1
     . $PSScriptRoot/../src/Private/Get-WindowsLicensingProduct.ps1
+    $script:MockCimSession = New-MockObject -Type 'Microsoft.Management.Infrastructure.CimSession'
 }
 
 Describe 'Get-WindowsLicensingProduct' {
@@ -17,7 +18,7 @@ Describe 'Get-WindowsLicensingProduct' {
         }
 
         It 'Returns the single product' {
-            $result = Get-WindowsLicensingProduct -CimSession $null
+            $result = Get-WindowsLicensingProduct -CimSession $script:MockCimSession
             $result.Name | Should -Be 'Windows 11 Pro'
         }
     }
@@ -28,7 +29,7 @@ Describe 'Get-WindowsLicensingProduct' {
         }
 
         It 'Throws with descriptive message' {
-            { Get-WindowsLicensingProduct -CimSession $null } |
+            { Get-WindowsLicensingProduct -CimSession $script:MockCimSession } |
                 Should -Throw -ExpectedMessage '*No Windows licensing product*'
         }
     }
@@ -44,7 +45,7 @@ Describe 'Get-WindowsLicensingProduct' {
         }
 
         It 'Returns the Licensed product' {
-            $result = Get-WindowsLicensingProduct -CimSession $null
+            $result = Get-WindowsLicensingProduct -CimSession $script:MockCimSession
             $result.Name | Should -Be 'Windows 11 Pro'
         }
     }
@@ -60,7 +61,7 @@ Describe 'Get-WindowsLicensingProduct' {
         }
 
         It 'Returns the active product' {
-            $result = Get-WindowsLicensingProduct -CimSession $null
+            $result = Get-WindowsLicensingProduct -CimSession $script:MockCimSession
             $result.Name | Should -Be 'Windows 11 Pro'
         }
     }
@@ -76,12 +77,12 @@ Describe 'Get-WindowsLicensingProduct' {
         }
 
         It 'Throws with candidate list' {
-            { Get-WindowsLicensingProduct -CimSession $null } |
+            { Get-WindowsLicensingProduct -CimSession $script:MockCimSession } |
                 Should -Throw -ExpectedMessage '*Multiple Windows licensing products*'
         }
 
         It 'Includes product names in the error' {
-            { Get-WindowsLicensingProduct -CimSession $null } |
+            { Get-WindowsLicensingProduct -CimSession $script:MockCimSession } |
                 Should -Throw -ExpectedMessage '*Windows 10 Pro*'
         }
     }

--- a/tests/Get-WindowsLicensingProduct.Tests.ps1
+++ b/tests/Get-WindowsLicensingProduct.Tests.ps1
@@ -1,0 +1,88 @@
+BeforeAll {
+    . $PSScriptRoot/../src/Private/LicenseStatusCode.ps1
+    . $PSScriptRoot/../src/Private/Get-WindowsLicensingProduct.ps1
+}
+
+Describe 'Get-WindowsLicensingProduct' {
+
+    Context 'Single matching product' {
+        BeforeEach {
+            Mock Get-CimInstance {
+                [PSCustomObject]@{
+                    Name              = 'Windows 11 Pro'
+                    LicenseStatus     = 1
+                    PartialProductKey = 'W7R9X'
+                }
+            }
+        }
+
+        It 'Returns the single product' {
+            $result = Get-WindowsLicensingProduct -CimSession $null
+            $result.Name | Should -Be 'Windows 11 Pro'
+        }
+    }
+
+    Context 'No matching products' {
+        BeforeEach {
+            Mock Get-CimInstance { @() }
+        }
+
+        It 'Throws with descriptive message' {
+            { Get-WindowsLicensingProduct -CimSession $null } |
+                Should -Throw -ExpectedMessage '*No Windows licensing product*'
+        }
+    }
+
+    Context 'Multiple products - one Licensed' {
+        BeforeEach {
+            Mock Get-CimInstance {
+                @(
+                    [PSCustomObject]@{ Name = 'Windows 10 Pro'; LicenseStatus = 5; PartialProductKey = 'XXXXX' }
+                    [PSCustomObject]@{ Name = 'Windows 11 Pro'; LicenseStatus = 1; PartialProductKey = 'YYYYY' }
+                )
+            }
+        }
+
+        It 'Returns the Licensed product' {
+            $result = Get-WindowsLicensingProduct -CimSession $null
+            $result.Name | Should -Be 'Windows 11 Pro'
+        }
+    }
+
+    Context 'Multiple products - one non-zero, none Licensed' {
+        BeforeEach {
+            Mock Get-CimInstance {
+                @(
+                    [PSCustomObject]@{ Name = 'Windows 10 Pro'; LicenseStatus = 0; PartialProductKey = 'XXXXX' }
+                    [PSCustomObject]@{ Name = 'Windows 11 Pro'; LicenseStatus = 5; PartialProductKey = 'YYYYY' }
+                )
+            }
+        }
+
+        It 'Returns the active product' {
+            $result = Get-WindowsLicensingProduct -CimSession $null
+            $result.Name | Should -Be 'Windows 11 Pro'
+        }
+    }
+
+    Context 'Multiple products - ambiguous' {
+        BeforeEach {
+            Mock Get-CimInstance {
+                @(
+                    [PSCustomObject]@{ Name = 'Windows 10 Pro'; LicenseStatus = 5; PartialProductKey = 'XXXXX' }
+                    [PSCustomObject]@{ Name = 'Windows 11 Pro'; LicenseStatus = 5; PartialProductKey = 'YYYYY' }
+                )
+            }
+        }
+
+        It 'Throws with candidate list' {
+            { Get-WindowsLicensingProduct -CimSession $null } |
+                Should -Throw -ExpectedMessage '*Multiple Windows licensing products*'
+        }
+
+        It 'Includes product names in the error' {
+            { Get-WindowsLicensingProduct -CimSession $null } |
+                Should -Throw -ExpectedMessage '*Windows 10 Pro*'
+        }
+    }
+}


### PR DESCRIPTION
Private functions:
- Get-LicenseStatus: fix operator precedence bug ([LicenseStatusCode]($product.LicenseStatus).LicenseStatus
  always returned 0); add Select-Object -First 1 for multi-row WQL safety
- Get-BasicLicenseInformation, Get-ExtendedLicenseInformation: add Select-Object -First 1
- Get-ExpiryInformation: remove dead case-0 branch (WQL filters it out); fix null/zero
  check for $graceRemaining on permanently-activated machines; move $endDate calculation
  inside branches that need it; fix -icontains -> -imatch for substring check; fix elif -> elseif
- Get-OfflineInstallationId, Invoke-OfflineActivation: fix WQL PartialProductKey <> null
  -> IS NOT NULL
- Get-Session: fix boolean operator precedence (add parens around $Computer[0] comparisons);
  implement DCOM session option for local connections (was using WSMan despite comment);
  fix remote session parameter passing (was positional $PSBoundParameters with wrong names)
- Get-KMSKey: add break to every branch to prevent fall-through; add trailing * to all
  client edition patterns for freeform Caption robustness; add missing Windows Server 2016
  (Standard/Datacenter/Essentials); add Azure Edition keys for Server 2022/2025 Datacenter
  (placed before plain Datacenter patterns so more-specific match wins); add Enterprise LTSC
  2019/2021/2024 keys with correct Caption patterns; add Education, Education N, Pro Education,
  Pro Education N editions for Win10 and Win11; fix Server 2019 EOS comment (Jan 2029 not Jan 2024)
- Invoke-KMSActivation: fix property access (.LicenseStatus -> .'License Status'); fix
  $KeyServerPort -> $KMSServerFQDN in SetKeyManagementServiceMachine argument; fix
  ContainsKey('KeyServerPort') -> 'KMSServerPort'; fix @{ $ProductKey = $ProductKey } ->
  @{ ProductKey = $productKey }; add missing SoftwareLicensingProduct.Activate() call to
  trigger KMS network check-in; add | Out-Null to CIM method calls; fix status messages
- Invoke-OfflineActivation: fix property access; fix WQL IS NOT NULL; change single-quoted
  Write-Debug strings to double-quoted for variable interpolation; remove pointless
  catch { throw }; add | Out-Null to RefreshLicenseStatus to prevent pipeline leak
- Invoke-Rearm: fix property access; replace [LicenseStatusCode]::Unknown (member does not
  exist) with $null check; remove Unlicensed from rearmable list (unreachable via WQL);
  upgrade Write-Verbose to Write-Warning on non-rearmable path for user visibility

Public functions:
- Get-WindowsActivation: remove SupportsShouldProcess (inappropriate for read-only function);
  move $results list init to Begin block (was re-created each Process call, breaking pipeline);
  fix End block nesting (was inside Process if-body, never executed as lifecycle block); add
  try/finally around session usage to guarantee Remove-CimSession on exception
- Start-WindowsActivation: remove ValueFromPipeline from KMSServerFQDN/KMSServerPort to
  prevent pipeline binding collision with $Computer; fix ConfirmationId validation to accept
  real CID format (9 dash-separated 6-digit groups) instead of 64 bare digits; move
  $session/$service retrieval inside try so session is cleaned up if Get-CimInstance throws;
  fix -$ConfirmationId syntax error -> -ConfirmationId $ConfirmationId; replace all exit 0
  / exit 1 calls with throw (exit kills the PowerShell process, breaking multi-computer loops
  and callers); fix inverted KMS cache verbose message; remove spurious Arguments hashtable
  from DisableKeyManagementServiceHostCaching (method takes no parameters); fix
  Invoke-KMSActivation call (was passing $PSBoundParameters positionally with wrong param
  names); use try/finally for guaranteed session cleanup

Module:
- slmgr-ps.psm1: load Private before Public (enum must be defined before function signatures
  that reference it); replace Write-Error with throw in catch to avoid terminating the caller
  under ErrorActionPreference=Stop while also surfacing real load failures
- slmgr-ps.psd1: restrict FunctionsToExport to public API only (was '*', leaking all private
  functions); restrict CmdletsToExport/VariablesToExport/AliasesToExport to @()

https://claude.ai/code/session_019Zg3UduwWP6LYbdig2KaQ8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 35+ defects across the activation module, adds safe helpers for product selection and method calls, introduces an opt‑in KMS client key install, normalizes output properties, and adds CI with tests for reliability. Also resets the KMS port to 1688 when only a server FQDN is provided and hardens CIM method error handling.

- **Bug Fixes**
  - Centralized product selection via `Get-WindowsLicensingProduct` (uses Windows licensing ApplicationID and requires `PartialProductKey IS NOT NULL`; disambiguates multi-candidate results with clearer error text).
  - Validated CIM method calls via `Invoke-SppCimMethod` (uses `-ErrorAction Stop` and throws on non‑zero ReturnValue), used across KMS, rearm, and offline flows.
  - KMS activation: only sets server/port when passed; default port 1688 is set when `-KMSServerFQDN` is provided without a port; optionally installs the GVLK when requested (`-UseKmsClientKey`); triggers `SoftwareLicensingProduct.Activate()` and refreshes status.
  - Offline activation: accepts CIDs with digits, dashes, or spaces (strips separators before submission); clearer debug output.
  - Output objects now use PascalCase property names (e.g., LicenseStatus, PartialProductKey, ExpirationInfo, UseLicenseUrl) to avoid brittle dotted access.
  - CI added and fixed: `PSScriptAnalyzer` linting, manifest/export checks (now run in a single step), and `Pester` tests on PS 5.1 and PS 7; expanded KMS key coverage; test stability fixed by using `New-MockObject` for `CimSession` to satisfy `[ValidateNotNull]`.

- **Migration**
  - Only `Get-WindowsActivation` and `Start-WindowsActivation` are exported; callers of private functions must import/dot‑source explicitly.
  - `Start-WindowsActivation` throws on failure (replaces `exit`); handle exceptions in callers.
  - `KMSServerFQDN`/`KMSServerPort` do not bind from pipeline; pass explicitly.
  - Offline activation requires a 9×6‑digit CID; dashes/spaces are allowed and will be ignored.
  - New opt‑in switch: `Start-WindowsActivation -UseKmsClientKey` installs the edition’s GVLK before activation (only when explicitly set).
  - Public outputs use PascalCase names (e.g., LicenseStatus, PartialProductKey, OfflineInstallationId, ExpirationInfo, UseLicenseUrl); update any scripts relying on old space‑separated names.

<sup>Written for commit 3e5319b0bd91a68e2cf5707fb7067368f66499bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zbalkan/slmgr-ps/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

