### PR TITLE
Implemented Reset-WindowsActivation and bumped the minor version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           Import-Module ./src/slmgr-ps.psd1 -Force
           $module = Get-Module slmgr-ps
           $exported = $module.ExportedFunctions.Keys | Sort-Object
-          $expected = @('Get-WindowsActivation', 'Start-WindowsActivation') | Sort-Object
+          $expected = @('Get-WindowsActivation', 'Reset-WindowsActivation', 'Start-WindowsActivation') | Sort-Object
           if (Compare-Object $exported $expected)
           {
               Write-Error "Exported functions do not match expected: got [$($exported -join ', ')], expected [$($expected -join ', ')]"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # slmgr-ps
 
-A PowerShell replacement for `slmgr.vbs` script (v1.1.0).
+A PowerShell replacement for `slmgr.vbs` script.
 
 Currently the features are limited to KMS and offline activation scenarios. See [Comparison](#comparison) for details.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # slmgr-ps
 
-A PowerShell replacement for `slmgr.vbs` script (v1.0.0).
+A PowerShell replacement for `slmgr.vbs` script (v1.1.0).
 
 Currently the features are limited to KMS and offline activation scenarios. See [Comparison](#comparison) for details.
 
@@ -50,13 +50,13 @@ slmgr.vbs [<ComputerName> [<User> <Password>]] [<Options>]
 
 | Option | Description | `slmgr-ps` | Notes |
 | - | - | - | - |
-| \/cpky | Some servicing operations require the product key to be available in the registry during Out-of-Box Experience (OOBE) operations. The **/cpky** option removes the product key from the registry to prevent this key from being stolen by malicious code.<br/>For retail installations that deploy keys, best practices recommend running this option. This option is not required for MAK and KMS host keys, because this is the default behavior for those keys. This option is required only for other types of keys whose default behavior is not to clear the key from the registry.<br/>This operation must be run in an elevated Command Prompt window. | not implemented | |
+| \/cpky | Some servicing operations require the product key to be available in the registry during Out-of-Box Experience (OOBE) operations. The **/cpky** option removes the product key from the registry to prevent this key from being stolen by malicious code.<br/>For retail installations that deploy keys, best practices recommend running this option. This option is not required for MAK and KMS host keys, because this is the default behavior for those keys. This option is required only for other types of keys whose default behavior is not to clear the key from the registry.<br/>This operation must be run in an elevated Command Prompt window. | Reset-WindowsActivation -ClearProductKeyFromRegistry | |
 | \/ilc *license_file* | This option installs the license file specified by the required parameter. These licenses may be installed as a troubleshooting measure, to support token-based activation, or as part of a manual installation of an on-boarded application.<br/>Licenses are not validated during this process: License validation is out of scope for Slmgr.vbs. Instead, validation is handled by the Software Protection Service at runtime.<br/>This operation must be run from an elevated Command Prompt window, or the **Standard User Operations** registry value must be set to allow unprivileged users extra access to the Software Protection Service. | not implemented | |
 | \/rilc | This option reinstalls all licenses stored in %SystemRoot%\system32\oem and %SystemRoot%\System32\spp\tokens. These are "known-good" copies that were stored during installation.<br/>Any matching licenses in the Trusted Store are replaced. Any additional licenses&mdash;for example, Trusted Authority (TA) Issuance Licenses (ILs), licenses for applications&mdash;are not affected.<br/>This operation must be run in an elevated Command Prompt window, or the **Standard User Operations** registry value must be set to allow unprivileged users extra access to the Software Protection Service. | not implemented | |
 | \/rearm | This option resets the activation timers. The **/rearm** process is also called by **sysprep /generalize**.<br/>This operation does nothing if the **HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SoftwareProtectionPlatform\SkipRearm** registry entry is set to **1**. See [Registry Settings for Volume Activation](/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/dn502532(v=ws.11)) for details about this registry entry.<br/>This operation must be run in an elevated Command Prompt window, or the **Standard User Operations** registry value must be set to allow unprivileged users extra access to the Software Protection Service. | Start-WindowsActivation -Rearm | |
 | \/rearm-app *Application ID* | Resets the licensing status of the specified app. | not implemented | |
 | \/rearm-sku *Application ID* | Resets the licensing status of the specified SKU. | not implemented | |
-| \/upk [*Application ID*] | This option uninstalls the product key of the current Windows edition. After a restart, the system will be in an Unlicensed state unless a new product key is installed.<br/>Optionally, you can use the ***Activation ID*** parameter to specify a different installed product.<br/>This operation must be run from an elevated Command Prompt window. | not implemented | |
+| \/upk [*Application ID*] | This option uninstalls the product key of the current Windows edition. After a restart, the system will be in an Unlicensed state unless a new product key is installed.<br/>Optionally, you can use the ***Activation ID*** parameter to specify a different installed product.<br/>This operation must be run from an elevated Command Prompt window. | Reset-WindowsActivation -UninstallProductKey | |
 | \/dti [*Activation ID*] | Displays installation ID for offline activation. | Get-WindowsActivation -Offline | |
 | \/atp *Confirmation ID* | Activate product by using user-provided confirmation ID. | Start-WindowsActivation -Offline -ConfirmationId <confirmation ID> | |
 
@@ -64,11 +64,11 @@ slmgr.vbs [<ComputerName> [<User> <Password>]] [<Options>]
 
 | Option | Description | `slmgr-ps` | Notes |
 | - | - | - | - |
-| \/skms *Name[:Port] \| \: port* [*Activation ID*] | This option specifies the name and, optionally, the port of the KMS host computer to contact. Setting this value disables auto-detection of the KMS host.<br/>If the KMS host uses Internet Protocol version 6 (IPv6) only, the address must be specified in the format *hostname*:*port*. IPv6 addresses contain colonsV, which the Slmgr.vbs script does not parse correctly.<br/>This operation must be run in an elevated Command Prompt window. | Start-WindowsActivation -KMSServerFQDN activationservername -KMSServerPort port | |
+| \/skms *Name[:Port] \| \: port* [*Activation ID*] | This option specifies the name and, optionally, the port of the KMS host computer to contact. Setting this value disables auto-detection of the KMS host.<br/>If the KMS host uses Internet Protocol version 6 (IPv6) only, the address must be specified in the format *hostname*:*port*. IPv6 addresses contain colons, which the Slmgr.vbs script does not parse correctly.<br/>This operation must be run in an elevated Command Prompt window. | Start-WindowsActivation -KMSServerFQDN activationservername -KMSServerPort port | |
 | \/skms-domain *FQDN* [*Activation ID*] | Sets the specific DNS domain in which all KMS SRV records can be found. This setting has no effect if the specific single KMS host is set by using the **/skms** option. Use this option, especially in disjoint namespace environments, to force KMS to ignore the DNS suffix search list and look for KMS host records in the specified DNS domain instead. | not implemented | |
-| \/ckms [*Activation ID*] | This option removes the specified KMS host name, address, and port information from the registry and restores KMS auto-discovery behavior.<br/>This operation must be run in an elevated Command Prompt window. | not implemented | |
-| \/skhc | This option enables KMS host caching (default). After the client discovers a working KMS host, this setting prevents the Domain Name System (DNS) priority and weight from affecting further communication with the host. If the system can no longer contact the working KMS host, the client tries to discover a new host.<br/>This operation must be run in an elevated Command Prompt window. | Start-WindowsActivation -CacheEnabled $true | KMS cache is enabled by default |
-| \/ckhc | This option disables KMS host caching. This setting instructs the client to use DNS auto-discovery each time it tries KMS activation (recommended when using priority and weight).<br/>This operation must be run in an elevated Command Prompt window. | Start-WindowsActivation -CacheEnabled $false | |
+| \/ckms [*Activation ID*] | This option removes the specified KMS host name, address, and port information from the registry and restores KMS auto-discovery behavior.<br/>This operation must be run in an elevated Command Prompt window. | Reset-WindowsActivation -ClearKMSSettings | |
+| \/skhc | This option enables KMS host caching (default). After the client discovers a working KMS host, this setting prevents the Domain Name System (DNS) priority and weight from affecting further communication with the host. If the system can no longer contact the working KMS host, the client tries to discover a new host.<br/>This operation must be run in an elevated Command Prompt window. | not implemented | KMS cache is enabled by default |
+| \/ckhc | This option disables KMS host caching. This setting instructs the client to use DNS auto-discovery each time it tries KMS activation (recommended when using priority and weight).<br/>This operation must be run in an elevated Command Prompt window. | Start-WindowsActivation -CacheDisabled | |
 
 #### KMS host configuration options
 
@@ -140,7 +140,7 @@ Start-WindowsActivation -Computer WS01
 Start-WindowsActivation -Computer WS01 -Credentials (Get-Credential)
 
 # Disables the KMS cache for the computers named WS01 and WS02. Cache is enabled by default.
-Start-WindowsActivation -Computer WS01, WS02 -CacheEnabled $false
+Start-WindowsActivation -Computer WS01, WS02 -CacheDisabled
 
 # Activates the computer named WS01 against server.domain.net:2500
 Start-WindowsActivation -Computer WS01 -KMSServerFQDN server.domain.net -KMSServerPort 2500
@@ -173,6 +173,25 @@ Get-WindowsActivation -Computer WS01 -Credentials (Get-Credential)
 
 # Get the offline installation ID for offline -aka phone- activation
 Get-WindowsActivation -Offline
+```
+
+### `Reset-WindowsActivation` cmdlet
+
+```powershell
+# Uninstall the product key (slmgr /upk)
+Reset-WindowsActivation -UninstallProductKey
+
+# Clear the product key from the registry (slmgr /cpky)
+Reset-WindowsActivation -ClearProductKeyFromRegistry
+
+# Clear KMS settings and restore auto-discovery (slmgr /ckms)
+Reset-WindowsActivation -ClearKMSSettings
+
+# Combine multiple operations in a single call
+Reset-WindowsActivation -UninstallProductKey -ClearProductKeyFromRegistry -ClearKMSSettings
+
+# Reset activation settings on a remote computer
+Reset-WindowsActivation -Computer WS01 -Credentials (Get-Credential) -UninstallProductKey -ClearProductKeyFromRegistry
 ```
 
 ### Advanced usage

--- a/src/Public/Reset-WindowsActivation.ps1
+++ b/src/Public/Reset-WindowsActivation.ps1
@@ -1,0 +1,135 @@
+#Requires -RunAsAdministrator
+#Requires -Version 5
+
+<#
+.Synopsis
+Resets Windows activation settings.
+.DESCRIPTION
+A drop in replacement for slmgr /upk, /cpky and /ckms commands. Uninstalls the product key,
+clears it from the registry, and/or clears KMS settings. Multiple switches can be combined
+in a single call.
+.INPUTS
+string[]. You can pass the computer names.
+.OUTPUTS
+None if successful. Throws on error.
+.EXAMPLE
+Reset-WindowsActivation -UninstallProductKey -Verbose
+.EXAMPLE
+Reset-WindowsActivation -UninstallProductKey -ClearProductKeyFromRegistry -Verbose
+.EXAMPLE
+Reset-WindowsActivation -ClearKMSSettings -Verbose
+.EXAMPLE
+Reset-WindowsActivation -Computer WS01 -Credentials (Get-Credential) -UninstallProductKey -ClearProductKeyFromRegistry -ClearKMSSettings
+.LINK
+https://github.com/zbalkan/slmgr-ps
+#>
+function Reset-WindowsActivation
+{
+    [CmdletBinding(SupportsShouldProcess = $true,
+        PositionalBinding = $false,
+        ConfirmImpact = 'High')]
+    Param
+    (
+        # Type localhost or . for local computer or do not use the parameter
+        [Parameter(Mandatory = $false,
+            Position = 0,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
+            ValueFromRemainingArguments = $false)]
+        [AllowNull()]
+        [string[]]
+        $Computer = @('localhost'),
+
+        # Define credentials other than current user if needed
+        [Parameter(Mandatory = $false,
+            ValueFromPipeline = $false,
+            ValueFromPipelineByPropertyName = $false,
+            ValueFromRemainingArguments = $false)]
+        [AllowNull()]
+        [PSCredential]
+        $Credentials,
+
+        # Uninstall the product key (slmgr /upk)
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $UninstallProductKey,
+
+        # Clear the product key from the registry (slmgr /cpky)
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $ClearProductKeyFromRegistry,
+
+        # Clear KMS settings (slmgr /ckms)
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $ClearKMSSettings
+    )
+    Begin
+    {
+        $PreviousPreference = $ErrorActionPreference
+        $ErrorActionPreference = 'Stop'
+        Write-Verbose 'ErrorActionPreference: Stop'
+
+        if (-not $UninstallProductKey.IsPresent -and -not $ClearProductKeyFromRegistry.IsPresent -and -not $ClearKMSSettings.IsPresent)
+        {
+            throw 'At least one reset operation must be specified: -UninstallProductKey, -ClearProductKeyFromRegistry, or -ClearKMSSettings.'
+        }
+    }
+    Process
+    {
+        Write-Verbose "Enumerating computers: $($Computer.Count) computer(s)."
+        foreach ($c in $Computer)
+        {
+            if (-not $PSCmdlet.ShouldProcess($c, 'Reset Windows activation settings'))
+            {
+                continue
+            }
+
+            Write-Verbose "Creating new CimSession for computer $c"
+            $session = $null
+            try
+            {
+                $session = Get-Session -Computer $c -Credentials $Credentials
+
+                if ($UninstallProductKey.IsPresent -or $ClearProductKeyFromRegistry.IsPresent)
+                {
+                    $product = Get-WindowsLicensingProduct -CimSession $session
+
+                    if ($UninstallProductKey.IsPresent)
+                    {
+                        Write-Verbose 'Uninstalling product key (slmgr /upk)'
+                        $product | Invoke-SppCimMethod -MethodName UninstallProductKey
+                    }
+
+                    if ($ClearProductKeyFromRegistry.IsPresent)
+                    {
+                        Write-Verbose 'Clearing product key from registry (slmgr /cpky)'
+                        $product | Invoke-SppCimMethod -MethodName ClearProductKeyFromRegistry
+                    }
+                }
+
+                if ($ClearKMSSettings.IsPresent)
+                {
+                    Write-Verbose 'Clearing KMS settings (slmgr /ckms)'
+                    $service = Get-CimInstance -CimSession $session -ClassName SoftwareLicensingService
+                    $service | Invoke-SppCimMethod -MethodName ClearKeyManagementServiceMachine
+                }
+            }
+            catch
+            {
+                throw
+            }
+            finally
+            {
+                if ($null -ne $session)
+                {
+                    Remove-CimSession -CimSession $session -ErrorAction Ignore | Out-Null
+                }
+            }
+        }
+    }
+    End
+    {
+        $ErrorActionPreference = $PreviousPreference
+    }
+}

--- a/src/slmgr-ps.psd1
+++ b/src/slmgr-ps.psd1
@@ -30,7 +30,7 @@
     Copyright         = '(c) Zafer Balkan. All rights reserved.'
 
     # Description of the functionality provided by this module
-    Description       = 'A drop in replacement for slmgr script'
+    Description       = 'A PowerShell replacement for slmgr.vbs script'
 
     # Minimum version of the Windows PowerShell engine required by this module
     # PowerShellVersion = ''

--- a/src/slmgr-ps.psd1
+++ b/src/slmgr-ps.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'slmgr-ps.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.0.0'
+    ModuleVersion     = '1.1.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -69,7 +69,7 @@
     # NestedModules = @()
 
     # Functions to export from this module
-    FunctionsToExport = @('Get-WindowsActivation', 'Start-WindowsActivation')
+    FunctionsToExport = @('Get-WindowsActivation', 'Reset-WindowsActivation', 'Start-WindowsActivation')
 
     # Cmdlets to export from this module
     CmdletsToExport   = @()

--- a/tests/Reset-WindowsActivation.Tests.ps1
+++ b/tests/Reset-WindowsActivation.Tests.ps1
@@ -1,0 +1,125 @@
+BeforeAll {
+    . $PSScriptRoot/../src/Private/LicenseStatusCode.ps1
+    . $PSScriptRoot/../src/Private/Get-Session.ps1
+    . $PSScriptRoot/../src/Private/Get-WindowsLicensingProduct.ps1
+
+    # Define a stub without the [CimInstance] type constraint so PSCustomObject
+    # mocks can flow through the pipeline without a ParameterBindingException.
+    function Invoke-SppCimMethod {
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory, ValueFromPipeline)]$InputObject,
+            [Parameter(Mandatory)][string]$MethodName,
+            [hashtable]$Arguments
+        )
+    }
+
+    . $PSScriptRoot/../src/Public/Reset-WindowsActivation.ps1
+    $script:MockCimSession = New-MockObject -Type 'Microsoft.Management.Infrastructure.CimSession'
+}
+
+Describe 'Reset-WindowsActivation' {
+
+    Context 'No switches specified' {
+        It 'Throws requiring at least one operation' {
+            { Reset-WindowsActivation -Confirm:$false } |
+                Should -Throw -ExpectedMessage '*At least one reset operation must be specified*'
+        }
+    }
+
+    Context 'UninstallProductKey' {
+        BeforeEach {
+            Mock Get-Session { $script:MockCimSession }
+            Mock Remove-CimSession {}
+            Mock Get-WindowsLicensingProduct {
+                [PSCustomObject]@{ Name = 'Windows 11 Pro'; LicenseStatus = 1 }
+            }
+            Mock Invoke-SppCimMethod {}
+        }
+
+        It 'Calls UninstallProductKey on the product' {
+            Reset-WindowsActivation -UninstallProductKey -Confirm:$false
+            Should -Invoke Invoke-SppCimMethod -ParameterFilter { $MethodName -eq 'UninstallProductKey' } -Times 1
+        }
+
+        It 'Does not call ClearProductKeyFromRegistry' {
+            Reset-WindowsActivation -UninstallProductKey -Confirm:$false
+            Should -Invoke Invoke-SppCimMethod -ParameterFilter { $MethodName -eq 'ClearProductKeyFromRegistry' } -Times 0
+        }
+
+        It 'Does not call ClearKeyManagementServiceMachine' {
+            Reset-WindowsActivation -UninstallProductKey -Confirm:$false
+            Should -Invoke Invoke-SppCimMethod -ParameterFilter { $MethodName -eq 'ClearKeyManagementServiceMachine' } -Times 0
+        }
+    }
+
+    Context 'ClearProductKeyFromRegistry' {
+        BeforeEach {
+            Mock Get-Session { $script:MockCimSession }
+            Mock Remove-CimSession {}
+            Mock Get-WindowsLicensingProduct {
+                [PSCustomObject]@{ Name = 'Windows 11 Pro'; LicenseStatus = 1 }
+            }
+            Mock Invoke-SppCimMethod {}
+        }
+
+        It 'Calls ClearProductKeyFromRegistry on the product' {
+            Reset-WindowsActivation -ClearProductKeyFromRegistry -Confirm:$false
+            Should -Invoke Invoke-SppCimMethod -ParameterFilter { $MethodName -eq 'ClearProductKeyFromRegistry' } -Times 1
+        }
+    }
+
+    Context 'ClearKMSSettings' {
+        BeforeEach {
+            Mock Get-Session { $script:MockCimSession }
+            Mock Remove-CimSession {}
+            Mock Get-WindowsLicensingProduct {}
+            Mock Get-CimInstance {
+                [PSCustomObject]@{ ClassName = 'SoftwareLicensingService' }
+            }
+            Mock Invoke-SppCimMethod {}
+        }
+
+        It 'Calls ClearKeyManagementServiceMachine on the service' {
+            Reset-WindowsActivation -ClearKMSSettings -Confirm:$false
+            Should -Invoke Invoke-SppCimMethod -ParameterFilter { $MethodName -eq 'ClearKeyManagementServiceMachine' } -Times 1
+        }
+
+        It 'Does not look up the product' {
+            Reset-WindowsActivation -ClearKMSSettings -Confirm:$false
+            Should -Invoke Get-WindowsLicensingProduct -Times 0
+        }
+    }
+
+    Context 'Combined switches' {
+        BeforeEach {
+            Mock Get-Session { $script:MockCimSession }
+            Mock Remove-CimSession {}
+            Mock Get-WindowsLicensingProduct {
+                [PSCustomObject]@{ Name = 'Windows 11 Pro'; LicenseStatus = 1 }
+            }
+            Mock Get-CimInstance {
+                [PSCustomObject]@{ ClassName = 'SoftwareLicensingService' }
+            }
+            Mock Invoke-SppCimMethod {}
+        }
+
+        It 'Calls all three methods when all switches are specified' {
+            Reset-WindowsActivation -UninstallProductKey -ClearProductKeyFromRegistry -ClearKMSSettings -Confirm:$false
+            Should -Invoke Invoke-SppCimMethod -Times 3
+        }
+    }
+
+    Context 'Session cleanup' {
+        BeforeEach {
+            Mock Get-Session { $script:MockCimSession }
+            Mock Remove-CimSession {}
+            Mock Get-WindowsLicensingProduct { throw 'Simulated failure' }
+        }
+
+        It 'Removes the CIM session even when an error occurs' {
+            { Reset-WindowsActivation -UninstallProductKey -Confirm:$false } | Should -Throw
+            Should -Invoke Remove-CimSession -Times 1
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/zbalkan/slmgr-ps/issues/8.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `Reset-WindowsActivation` to reset Windows activation by uninstalling the product key, clearing it from the registry, and clearing KMS settings. Bumps the module to v1.1.0 and refreshes docs, tests, CI, and module metadata.

- **New Features**
  - Added `Reset-WindowsActivation` with `-UninstallProductKey`, `-ClearProductKeyFromRegistry`, and `-ClearKMSSettings`. Supports local/remote via `-Computer`/`-Credentials`, combines switches, and honors `-WhatIf`/`-Confirm`.
  - Exported the cmdlet; updated README with option mappings and examples; added Pester tests; CI updated to expect the new export; module description metadata updated.

<sup>Written for commit e0eeea8d8cee25bba15544a8b27c5f7096350f37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zbalkan/slmgr-ps/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

